### PR TITLE
Proposed solution to issue #25 related to gulp extend npm search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Change Log
 
+## [v8.0.0-beta.1](https://github.com/liferay/liferay-themes-sdk/tree/v8.0.0-beta.1) (2018-07-11)
+[Full Changelog](https://github.com/liferay/liferay-themes-sdk/compare/v8.0.0-beta.0...v8.0.0-beta.1)
+
+**Merged pull requests:**
+
+- v8.0.0-beta.1 [\#23](https://github.com/liferay/liferay-themes-sdk/pull/23) ([jbalsas](https://github.com/jbalsas))
+- Adds namespace option to config-generator [\#22](https://github.com/liferay/liferay-themes-sdk/pull/22) ([jbalsas](https://github.com/jbalsas))
+- Handles inexistent npm module exception properly [\#20](https://github.com/liferay/liferay-themes-sdk/pull/20) ([jbalsas](https://github.com/jbalsas))
+
+## [v8.0.0-beta.0](https://github.com/liferay/liferay-themes-sdk/tree/v8.0.0-beta.0) (2018-07-03)
+[Full Changelog](https://github.com/liferay/liferay-themes-sdk/compare/v8.0.0-alpha.6...v8.0.0-beta.0)
+
+**Closed issues:**
+
+- Deprecation support in the generator [\#15](https://github.com/liferay/liferay-themes-sdk/issues/15)
+
+**Merged pull requests:**
+
+- fix-deprecation-prompt [\#16](https://github.com/liferay/liferay-themes-sdk/pull/16) ([natecavanaugh](https://github.com/natecavanaugh))
+
+## [v8.0.0-alpha.6](https://github.com/liferay/liferay-themes-sdk/tree/v8.0.0-alpha.6) (2018-06-18)
+[Full Changelog](https://github.com/liferay/liferay-themes-sdk/compare/v8.0.0-alpha.5...v8.0.0-alpha.6)
+
+## [v8.0.0-alpha.5](https://github.com/liferay/liferay-themes-sdk/tree/v8.0.0-alpha.5) (2018-06-18)
+[Full Changelog](https://github.com/liferay/liferay-themes-sdk/compare/v8.0.0-alpha.4...v8.0.0-alpha.5)
+
+**Fixed bugs:**
+
+- Npm's github repository links points to old repository for the majority of the packages [\#12](https://github.com/liferay/liferay-themes-sdk/issues/12)
+
+**Merged pull requests:**
+
+- v2.0.0-beta.5 [\#14](https://github.com/liferay/liferay-themes-sdk/pull/14) ([jbalsas](https://github.com/jbalsas))
+- Updates repository fields in package.json files [\#13](https://github.com/liferay/liferay-themes-sdk/pull/13) ([jbalsas](https://github.com/jbalsas))
+- Replaces usages of gulp-util. [\#9](https://github.com/liferay/liferay-themes-sdk/pull/9) ([jbalsas](https://github.com/jbalsas))
+
 ## [v8.0.0-alpha.4](https://github.com/liferay/liferay-themes-sdk/tree/v8.0.0-alpha.4) (2018-03-23)
 [Full Changelog](https://github.com/liferay/liferay-themes-sdk/compare/v8.0.0-alpha.3...v8.0.0-alpha.4)
 

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -178,13 +178,15 @@ module.exports = {
 				countMatchesName++;
 			}
 
-			if (description && (description.toLowerCase().indexOf(term) > -1)) {
+			if (description && description.toLowerCase().indexOf(term) > -1) {
 				countMatchesDesc++;
 			}
 		});
 
-		return ((countMatchesName / searchTermsArr.length) > threshold) ||
-            ((countMatchesDesc / searchTermsArr.length) > threshold);
+		return (
+			countMatchesName / searchTermsArr.length > threshold ||
+			countMatchesDesc / searchTermsArr.length > threshold
+		);
 	},
 
 	_reduceModuleResults: function(modules, config) {

--- a/packages/liferay-theme-tasks/lib/theme_finder.js
+++ b/packages/liferay-theme-tasks/lib/theme_finder.js
@@ -3,7 +3,7 @@
 let _ = require('lodash');
 let async = require('async');
 let globby = require('globby');
-let npmKeyword = require('npm-keyword');
+let npmKeyword = require('npms-keyword');
 let packageJson = require('package-json');
 let path = require('path');
 let spawn = require('cross-spawn');
@@ -168,11 +168,23 @@ module.exports = {
 
 	_matchesSearchTerms: function(pkg, searchTerms) {
 		let description = pkg.description;
+		let threshold = 0.7;
+		let countMatchesName = 0;
+		let countMatchesDesc = 0;
 
-		return (
-			pkg.name.indexOf(searchTerms) > -1 ||
-			(description && description.indexOf(searchTerms) > -1)
-		);
+		let searchTermsArr = searchTerms.split(/\s/g);
+		searchTermsArr.map(term => {
+			if (pkg.name.toLowerCase().indexOf(term) > -1) {
+				countMatchesName++;
+			}
+
+			if (description && (description.toLowerCase().indexOf(term) > -1)) {
+				countMatchesDesc++;
+			}
+		});
+
+		return ((countMatchesName / searchTermsArr.length) > threshold) ||
+            ((countMatchesDesc / searchTermsArr.length) > threshold);
 	},
 
 	_reduceModuleResults: function(modules, config) {

--- a/packages/liferay-theme-tasks/package-lock.json
+++ b/packages/liferay-theme-tasks/package-lock.json
@@ -1,8084 +1,7933 @@
 {
-	"name": "liferay-theme-tasks",
-	"version": "8.0.0-beta.0",
-	"lockfileVersion": 1,
-	"requires": true,
-	"dependencies": {
-		"@sindresorhus/is": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-			"integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
-		},
-		"abbrev": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-		},
-		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-			"requires": {
-				"mime-types": "2.1.18",
-				"negotiator": "0.6.1"
-			}
-		},
-		"after": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-			"integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
-		},
-		"amdefine": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-			"integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-		},
-		"ansi-align": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-			"integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-			"requires": {
-				"string-width": "1.0.2"
-			}
-		},
-		"ansi-colors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
-			"integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
-			"requires": {
-				"ansi-wrap": "0.1.0"
-			}
-		},
-		"ansi-escapes": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
-		},
-		"ansi-gray": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-			"requires": {
-				"ansi-wrap": "0.1.0"
-			}
-		},
-		"ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-		},
-		"ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
-		},
-		"ansi-wrap": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
-		},
-		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "1.1.0"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"requires": {
-						"is-posix-bracket": "0.1.1"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
-					}
-				}
-			}
-		},
-		"applause": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/applause/-/applause-0.4.3.tgz",
-			"integrity": "sha1-Zmy9fw+c5U3L3mcM7qguYTORvb0=",
-			"requires": {
-				"cson-parser": "1.3.5",
-				"js-yaml": "3.11.0",
-				"lodash": "3.10.1"
-			}
-		},
-		"aproba": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-		},
-		"archy": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-			"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
-		},
-		"are-we-there-yet": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-			"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-			"requires": {
-				"delegates": "1.0.0",
-				"readable-stream": "2.3.5"
-			}
-		},
-		"argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"requires": {
-				"sprintf-js": "1.0.3"
-			}
-		},
-		"arr-diff": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
-		},
-		"arr-flatten": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
-		},
-		"arr-union": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
-		},
-		"array-differ": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-			"integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
-		},
-		"array-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
-			"integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
-		},
-		"array-find-index": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-			"integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-		},
-		"array-slice": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
-			"integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
-		},
-		"array-union": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"requires": {
-				"array-uniq": "1.0.3"
-			}
-		},
-		"array-uniq": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-			"integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
-		},
-		"array-unique": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
-		},
-		"arraybuffer.slice": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-			"integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
-		},
-		"arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
-		},
-		"asn1": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-			"integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-		},
-		"assert-plus": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-			"integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
-		},
-		"assign-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
-		},
-		"async": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-			"requires": {
-				"lodash": "4.17.10"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				}
-			}
-		},
-		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
-		},
-		"async-each-series": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-			"integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
-		},
-		"async-foreach": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-			"integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
-		},
-		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
-		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-		},
-		"atob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
-			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
-		},
-		"aws-sign2": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-			"integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
-		},
-		"aws4": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
-		},
-		"axios": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
-			"requires": {
-				"follow-redirects": "1.5.0",
-				"is-buffer": "1.1.6"
-			}
-		},
-		"backo2": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-			"integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
-		},
-		"balanced-match": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-		},
-		"base": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"requires": {
-				"cache-base": "1.0.1",
-				"class-utils": "0.3.6",
-				"component-emitter": "1.2.1",
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"mixin-deep": "1.3.1",
-				"pascalcase": "0.1.1"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "1.0.2"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				}
-			}
-		},
-		"base64-arraybuffer": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-			"integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
-		},
-		"base64id": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
-			"integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
-		},
-		"batch": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
-			"integrity": "sha1-PzQU84AyF0O/wQQvmoP/HVgk1GQ="
-		},
-		"bcrypt-pbkdf": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-			"optional": true,
-			"requires": {
-				"tweetnacl": "0.14.5"
-			}
-		},
-		"beeper": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
-		},
-		"better-assert": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
-			"integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
-			"requires": {
-				"callsite": "1.0.0"
-			}
-		},
-		"binary-extensions": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-			"integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
-		},
-		"blob": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-			"integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
-		},
-		"block-stream": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"requires": {
-				"inherits": "2.0.3"
-			}
-		},
-		"bluebird": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-			"integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
-		},
-		"body-parser": {
-			"version": "1.14.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
-			"integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
-			"requires": {
-				"bytes": "2.2.0",
-				"content-type": "1.0.4",
-				"debug": "2.2.0",
-				"depd": "1.1.2",
-				"http-errors": "1.3.1",
-				"iconv-lite": "0.4.13",
-				"on-finished": "2.3.0",
-				"qs": "5.2.0",
-				"raw-body": "2.1.7",
-				"type-is": "1.6.16"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-				},
-				"qs": {
-					"version": "5.2.0",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-					"integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4="
-				}
-			}
-		},
-		"boom": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"requires": {
-				"hoek": "2.16.3"
-			}
-		},
-		"bourbon": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.3.tgz",
-			"integrity": "sha1-1gYckMDihzfBoNAVZy1yvpdw//A="
-		},
-		"boxen": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
-			"integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
-			"requires": {
-				"ansi-align": "1.1.0",
-				"camelcase": "2.1.1",
-				"chalk": "1.1.3",
-				"cli-boxes": "1.0.0",
-				"filled-array": "1.1.0",
-				"object-assign": "4.1.1",
-				"repeating": "2.0.1",
-				"string-width": "1.0.2",
-				"widest-line": "1.0.0"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"requires": {
-				"balanced-match": "1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"braces": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"requires": {
-				"arr-flatten": "1.1.0",
-				"array-unique": "0.3.2",
-				"extend-shallow": "2.0.1",
-				"fill-range": "4.0.0",
-				"isobject": "3.0.1",
-				"repeat-element": "1.1.2",
-				"snapdragon": "0.8.2",
-				"snapdragon-node": "2.1.1",
-				"split-string": "3.1.0",
-				"to-regex": "3.0.2"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "0.1.1"
-					}
-				}
-			}
-		},
-		"browser-sync": {
-			"version": "2.24.4",
-			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.4.tgz",
-			"integrity": "sha512-qfXv8vQA/Dctub2v44v/vPuvfC4XNd6bn+W5vWZVuhuy6w91lPsdY6qhalT2s2PjnJ3FR6kWq5wkTQgN26eKzA==",
-			"requires": {
-				"browser-sync-ui": "1.0.1",
-				"bs-recipes": "1.3.4",
-				"chokidar": "1.7.0",
-				"connect": "3.5.0",
-				"connect-history-api-fallback": "1.5.0",
-				"dev-ip": "1.0.1",
-				"easy-extender": "2.3.2",
-				"eazy-logger": "3.0.2",
-				"etag": "1.8.1",
-				"fresh": "0.5.2",
-				"fs-extra": "3.0.1",
-				"http-proxy": "1.15.2",
-				"immutable": "3.8.2",
-				"localtunnel": "1.9.0",
-				"micromatch": "2.3.11",
-				"opn": "4.0.2",
-				"portscanner": "2.1.1",
-				"qs": "6.2.3",
-				"raw-body": "2.3.3",
-				"resp-modifier": "6.0.2",
-				"rx": "4.1.0",
-				"serve-index": "1.8.0",
-				"serve-static": "1.13.2",
-				"server-destroy": "1.0.1",
-				"socket.io": "2.0.4",
-				"ua-parser-js": "0.7.17",
-				"yargs": "6.4.0"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"requires": {
-						"arr-flatten": "1.1.0"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"requires": {
-						"expand-range": "1.8.2",
-						"preserve": "0.2.0",
-						"repeat-element": "1.1.2"
-					}
-				},
-				"bytes": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-					"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-				},
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"requires": {
-						"is-posix-bracket": "0.1.1"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-					"integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"jsonfile": "3.0.1",
-						"universalify": "0.1.1"
-					}
-				},
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"requires": {
-						"depd": "1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": "1.4.0"
-					}
-				},
-				"iconv-lite": {
-					"version": "0.4.23",
-					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-					"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-					"requires": {
-						"safer-buffer": "2.1.2"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				},
-				"jsonfile": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-					"integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-					"requires": {
-						"graceful-fs": "4.1.11"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				},
-				"micromatch": {
-					"version": "2.3.11",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-					"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-					"requires": {
-						"arr-diff": "2.0.0",
-						"array-unique": "0.2.1",
-						"braces": "1.8.5",
-						"expand-brackets": "0.1.5",
-						"extglob": "0.3.2",
-						"filename-regex": "2.0.1",
-						"is-extglob": "1.0.0",
-						"is-glob": "2.0.1",
-						"kind-of": "3.2.2",
-						"normalize-path": "2.1.1",
-						"object.omit": "2.0.1",
-						"parse-glob": "3.0.4",
-						"regex-cache": "0.4.4"
-					}
-				},
-				"qs": {
-					"version": "6.2.3",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
-					"integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
-				},
-				"raw-body": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-					"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-					"requires": {
-						"bytes": "3.0.0",
-						"http-errors": "1.6.3",
-						"iconv-lite": "0.4.23",
-						"unpipe": "1.0.0"
-					}
-				},
-				"yargs": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
-					"integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"window-size": "0.2.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "3.0.0"
-					}
-				}
-			}
-		},
-		"browser-sync-ui": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
-			"integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
-			"requires": {
-				"async-each-series": "0.1.1",
-				"connect-history-api-fallback": "1.5.0",
-				"immutable": "3.8.2",
-				"server-destroy": "1.0.1",
-				"socket.io-client": "2.0.4",
-				"stream-throttle": "0.1.3"
-			}
-		},
-		"bs-recipes": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
-			"integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
-		},
-		"buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
-		},
-		"buffer-from": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-			"integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
-		},
-		"builtin-modules": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-		},
-		"bytes": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-			"integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg="
-		},
-		"cache-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"requires": {
-				"collection-visit": "1.0.0",
-				"component-emitter": "1.2.1",
-				"get-value": "2.0.6",
-				"has-value": "1.0.0",
-				"isobject": "3.0.1",
-				"set-value": "2.0.0",
-				"to-object-path": "0.3.0",
-				"union-value": "1.0.0",
-				"unset-value": "1.0.0"
-			}
-		},
-		"cacheable-request": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-			"integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
-			"requires": {
-				"clone-response": "1.0.2",
-				"get-stream": "3.0.0",
-				"http-cache-semantics": "3.8.1",
-				"keyv": "3.0.0",
-				"lowercase-keys": "1.0.0",
-				"normalize-url": "2.0.1",
-				"responselike": "1.0.2"
-			}
-		},
-		"callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-		},
-		"camelcase": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-		},
-		"camelcase-keys": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
-			}
-		},
-		"capture-stack-trace": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-			"integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
-		},
-		"caseless": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-			"integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
-		},
-		"chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
-			}
-		},
-		"chokidar": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-			"integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-			"requires": {
-				"anymatch": "1.3.2",
-				"async-each": "1.0.1",
-				"fsevents": "1.2.4",
-				"glob-parent": "2.0.0",
-				"inherits": "2.0.3",
-				"is-binary-path": "1.0.1",
-				"is-glob": "2.0.1",
-				"path-is-absolute": "1.0.1",
-				"readdirp": "2.1.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				}
-			}
-		},
-		"class-utils": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"requires": {
-				"arr-union": "3.1.0",
-				"define-property": "0.2.5",
-				"isobject": "3.0.1",
-				"static-extend": "0.1.2"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "0.1.6"
-					}
-				}
-			}
-		},
-		"clay": {
-			"version": "2.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/clay/-/clay-2.0.0-rc.9.tgz",
-			"integrity": "sha512-EW1NFhUwOetG9HbaZYoqZlK2eYrfZHVnK36IrlkSpNnrLbPfJzU0eHbVYFfYsNKcb5rH5x9McRKtJgRzGhC8ww=="
-		},
-		"cli": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
-			"integrity": "sha1-ePlIXNFhtWbppsctcXDEJw6B22E=",
-			"requires": {
-				"glob": "7.1.2"
-			}
-		},
-		"cli-boxes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-			"integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
-		},
-		"cli-color": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
-			"integrity": "sha1-CiXOrlpqFgK+f3fShWPDZwAnTog=",
-			"requires": {
-				"es5-ext": "0.9.2",
-				"memoizee": "0.2.6"
-			}
-		},
-		"cli-color-keywords": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/cli-color-keywords/-/cli-color-keywords-0.0.1.tgz",
-			"integrity": "sha1-3eoJX653nJ5LT0FYHsenbbSOlLc=",
-			"requires": {
-				"chalk": "1.1.3",
-				"lodash": "3.10.1"
-			}
-		},
-		"cli-cursor": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-			"requires": {
-				"restore-cursor": "1.0.1"
-			}
-		},
-		"cli-width": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-		},
-		"cliui": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wrap-ansi": "2.1.0"
-			}
-		},
-		"clone": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
-		},
-		"clone-buffer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-			"integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
-		},
-		"clone-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
-			"integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
-			"requires": {
-				"mimic-response": "1.0.0"
-			}
-		},
-		"clone-stats": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
-		},
-		"cloneable-readable": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
-			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
-			"requires": {
-				"inherits": "2.0.3",
-				"process-nextick-args": "2.0.0",
-				"readable-stream": "2.3.5"
-			}
-		},
-		"code-point-at": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-		},
-		"coffee-script": {
-			"version": "1.12.7",
-			"resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-			"integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
-		},
-		"collection-visit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-			"requires": {
-				"map-visit": "1.0.0",
-				"object-visit": "1.0.1"
-			}
-		},
-		"color-support": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
-		},
-		"combined-stream": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-			"requires": {
-				"delayed-stream": "1.0.0"
-			}
-		},
-		"commander": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
-		},
-		"compass-mixins": {
-			"version": "0.12.10",
-			"resolved": "https://registry.npmjs.org/compass-mixins/-/compass-mixins-0.12.10.tgz",
-			"integrity": "sha1-zZ8V+CnE6WDMQ7sibwSbKL65nUE="
-		},
-		"component-bind": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-			"integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-		},
-		"component-emitter": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
-		},
-		"component-inherit": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-		},
-		"concat-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-			"requires": {
-				"buffer-from": "1.0.0",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.5",
-				"typedarray": "0.0.6"
-			}
-		},
-		"concat-with-sourcemaps": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.5.tgz",
-			"integrity": "sha512-YtnS0VEY+e2Khzsey/6mra9EoM6h/5gxaC0e3mcHpA5yfDxafhygytNmcJWodvUgyXzSiL5MSkPO6bQGgfliHw==",
-			"requires": {
-				"source-map": "0.6.1"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				}
-			}
-		},
-		"configstore": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
-			"integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-			"requires": {
-				"dot-prop": "3.0.0",
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1",
-				"os-tmpdir": "1.0.2",
-				"osenv": "0.1.5",
-				"uuid": "2.0.3",
-				"write-file-atomic": "1.3.4",
-				"xdg-basedir": "2.0.0"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				},
-				"uuid": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-					"integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
-				}
-			}
-		},
-		"connect": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/connect/-/connect-3.5.0.tgz",
-			"integrity": "sha1-s1dSWgtMH1BZnNmD4dnv7qlncZg=",
-			"requires": {
-				"debug": "2.2.0",
-				"finalhandler": "0.5.0",
-				"parseurl": "1.3.2",
-				"utils-merge": "1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-				}
-			}
-		},
-		"connect-history-api-fallback": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
-		},
-		"console-control-strings": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-		},
-		"content-formatter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/content-formatter/-/content-formatter-1.1.0.tgz",
-			"integrity": "sha1-N4/I4IDGF/pAvN/GwdiMNJ40wfo=",
-			"requires": {
-				"drip": "1.4.0",
-				"lodash": "3.10.1",
-				"string-sub": "0.0.1"
-			}
-		},
-		"content-logger": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/content-logger/-/content-logger-0.0.3.tgz",
-			"integrity": "sha1-6s1fuI8e4tT5BFNYfqaOIaf0n9I=",
-			"requires": {
-				"content-logger-handlebars-helpers": "0.0.1",
-				"drip": "1.4.0",
-				"lodash": "3.10.1"
-			}
-		},
-		"content-logger-handlebars-helpers": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/content-logger-handlebars-helpers/-/content-logger-handlebars-helpers-0.0.1.tgz",
-			"integrity": "sha1-V797IGgUio4PZItp+SnF0qUNQr0=",
-			"requires": {
-				"cli-color-keywords": "0.0.1",
-				"handlebars": "3.0.3",
-				"lodash": "3.10.1"
-			}
-		},
-		"content-type": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-		},
-		"convert-bootstrap-2-to-3": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/convert-bootstrap-2-to-3/-/convert-bootstrap-2-to-3-1.0.4.tgz",
-			"integrity": "sha512-hs6uQNMSyeRao5G3z4gu+lYVLXC2zt8FDSN2VilUq+lWQLJKgIRDrHufhjQ7Xpy8ZsWQ3CSOBJG93so7BXOYDQ==",
-			"requires": {
-				"async": "0.7.0",
-				"cli": "0.4.5",
-				"cli-color-keywords": "0.0.1",
-				"content-formatter": "1.1.0",
-				"content-logger": "0.0.3",
-				"diff": "1.4.0",
-				"lodash": "3.10.1",
-				"optimist": "0.6.1",
-				"roolz": "1.0.2",
-				"string-sub": "0.0.1",
-				"to-int": "0.1.0"
-			},
-			"dependencies": {
-				"async": {
-					"version": "0.7.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.7.0.tgz",
-					"integrity": "sha1-RCng5i9d4KVPN0WMSfC4l+tSraU="
-				}
-			}
-		},
-		"convert-source-map": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-			"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
-		},
-		"cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-		},
-		"copy-descriptor": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"create-error-class": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-			"integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-			"requires": {
-				"capture-stack-trace": "1.0.0"
-			}
-		},
-		"cross-spawn": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
-			"integrity": "sha1-+sViAt/T0N2GF3jy2iA79DS7ghw=",
-			"requires": {
-				"cross-spawn-async": "2.2.5",
-				"spawn-sync": "1.0.15"
-			}
-		},
-		"cross-spawn-async": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-			"integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-			"requires": {
-				"lru-cache": "4.1.2",
-				"which": "1.3.0"
-			}
-		},
-		"cryptiles": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"requires": {
-				"boom": "2.10.1"
-			}
-		},
-		"cson-parser": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
-			"integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
-			"requires": {
-				"coffee-script": "1.12.7"
-			}
-		},
-		"css-stringify": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.4.1.tgz",
-			"integrity": "sha1-JSzL8D9yOgCb3Ydw/n6ydBca/fo=",
-			"requires": {
-				"source-map": "0.1.43"
-			}
-		},
-		"currently-unhandled": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"requires": {
-				"array-find-index": "1.0.2"
-			}
-		},
-		"dargs": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/dargs/-/dargs-2.1.0.tgz",
-			"integrity": "sha1-RsJ/+rH/sTeO8hJZchNxn+YCvJM="
-		},
-		"dashdash": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
-				"assert-plus": "1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
-		},
-		"dateformat": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-			"integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
-		},
-		"debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"requires": {
-				"ms": "2.0.0"
-			}
-		},
-		"decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
-		},
-		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
-		},
-		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
-			"requires": {
-				"mimic-response": "1.0.0"
-			}
-		},
-		"deep-extend": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
-		},
-		"defaults": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"requires": {
-				"clone": "1.0.3"
-			}
-		},
-		"define-property": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"requires": {
-				"is-descriptor": "1.0.2",
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				}
-			}
-		},
-		"del": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/del/-/del-1.2.1.tgz",
-			"integrity": "sha1-rtblvNfLcyXfNPVjEl+iZbLBoBQ=",
-			"requires": {
-				"each-async": "1.1.1",
-				"globby": "2.1.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
-				"object-assign": "3.0.0",
-				"rimraf": "2.6.2"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				},
-				"glob": {
-					"version": "5.0.15",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"globby": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
-					"integrity": "sha1-npGSvNM/Srak+JTl5+qLcTITxII=",
-					"requires": {
-						"array-union": "1.0.2",
-						"async": "1.5.2",
-						"glob": "5.0.15",
-						"object-assign": "3.0.0"
-					}
-				}
-			}
-		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-		},
-		"delegates": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-		},
-		"depd": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-			"integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-		},
-		"deprecated": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
-			"integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
-		},
-		"destroy": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-			"integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-		},
-		"detect-file": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
-			"integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
-		},
-		"dev-ip": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
-			"integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
-		},
-		"diff": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-			"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
-		},
-		"dot-prop": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-			"integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-			"requires": {
-				"is-obj": "1.0.1"
-			}
-		},
-		"drip": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/drip/-/drip-1.4.0.tgz",
-			"integrity": "sha1-JDhhZq2QrsZ9aYYaGAieET7fJgI=",
-			"requires": {
-				"tea-concat": "0.1.0"
-			}
-		},
-		"duplexer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
-		},
-		"duplexer2": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-			"requires": {
-				"readable-stream": "1.1.14"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
-			}
-		},
-		"duplexer3": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-			"integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-		},
-		"duplexify": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
-			"requires": {
-				"end-of-stream": "1.4.1",
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.5",
-				"stream-shift": "1.0.0"
-			},
-			"dependencies": {
-				"end-of-stream": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-					"requires": {
-						"once": "1.4.0"
-					}
-				}
-			}
-		},
-		"each-async": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-			"integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
-			"requires": {
-				"onetime": "1.1.0",
-				"set-immediate-shim": "1.0.1"
-			}
-		},
-		"easy-extender": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
-			"integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
-			"requires": {
-				"lodash": "3.10.1"
-			}
-		},
-		"eazy-logger": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
-			"integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
-			"requires": {
-				"tfunk": "3.1.0"
-			}
-		},
-		"ecc-jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-			"optional": true,
-			"requires": {
-				"jsbn": "0.1.1"
-			}
-		},
-		"ee-first": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-		},
-		"encodeurl": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-			"integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-		},
-		"end-of-stream": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
-			"integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
-			"requires": {
-				"once": "1.3.3"
-			},
-			"dependencies": {
-				"once": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-					"integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				}
-			}
-		},
-		"engine.io": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.1.5.tgz",
-			"integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
-			"requires": {
-				"accepts": "1.3.5",
-				"base64id": "1.0.0",
-				"cookie": "0.3.1",
-				"debug": "3.1.0",
-				"engine.io-parser": "2.1.2",
-				"uws": "9.14.0",
-				"ws": "3.3.3"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"engine.io-client": {
-			"version": "3.1.6",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
-			"integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
-			"requires": {
-				"component-emitter": "1.2.1",
-				"component-inherit": "0.0.3",
-				"debug": "3.1.0",
-				"engine.io-parser": "2.1.2",
-				"has-cors": "1.1.0",
-				"indexof": "0.0.1",
-				"parseqs": "0.0.5",
-				"parseuri": "0.0.5",
-				"ws": "3.3.3",
-				"xmlhttprequest-ssl": "1.5.5",
-				"yeast": "0.1.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"engine.io-parser": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
-			"integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
-			"requires": {
-				"after": "0.8.2",
-				"arraybuffer.slice": "0.0.7",
-				"base64-arraybuffer": "0.1.5",
-				"blob": "0.0.4",
-				"has-binary2": "1.0.3"
-			}
-		},
-		"error-ex": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"requires": {
-				"is-arrayish": "0.2.1"
-			}
-		},
-		"es5-ext": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
-			"integrity": "sha1-0uMJ0fIjsHGGSINaz1uII6gGH4o="
-		},
-		"escape-html": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-			"integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
-		"esprima": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
-		},
-		"etag": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-		},
-		"event-emitter": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
-			"integrity": "sha1-yB43JOtVQHxaDV7jKZQR9wD1QpE=",
-			"requires": {
-				"es5-ext": "0.9.2"
-			}
-		},
-		"event-stream": {
-			"version": "3.3.4",
-			"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-			"requires": {
-				"duplexer": "0.1.1",
-				"from": "0.1.7",
-				"map-stream": "0.1.0",
-				"pause-stream": "0.0.11",
-				"split": "0.3.3",
-				"stream-combiner": "0.0.4",
-				"through": "2.3.8"
-			}
-		},
-		"eventemitter3": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
-			"integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
-		},
-		"exit-hook": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
-		},
-		"expand-brackets": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-			"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-			"requires": {
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"posix-character-classes": "0.1.1",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "0.1.6"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "0.1.1"
-					}
-				}
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"requires": {
-				"fill-range": "2.2.4"
-			},
-			"dependencies": {
-				"fill-range": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"requires": {
-						"is-number": "2.1.0",
-						"isobject": "2.1.0",
-						"randomatic": "3.0.0",
-						"repeat-element": "1.1.2",
-						"repeat-string": "1.6.1"
-					}
-				},
-				"is-number": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"requires": {
-						"kind-of": "3.2.2"
-					}
-				},
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"requires": {
-						"isarray": "1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"expand-tilde": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-			"integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-			"requires": {
-				"homedir-polyfill": "1.0.1"
-			}
-		},
-		"extend": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-		},
-		"extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-			"requires": {
-				"assign-symbols": "1.0.0",
-				"is-extendable": "1.0.1"
-			},
-			"dependencies": {
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"requires": {
-						"is-plain-object": "2.0.4"
-					}
-				}
-			}
-		},
-		"extglob": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"requires": {
-				"array-unique": "0.3.2",
-				"define-property": "1.0.0",
-				"expand-brackets": "2.1.4",
-				"extend-shallow": "2.0.1",
-				"fragment-cache": "0.2.1",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "1.0.2"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "0.1.1"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				}
-			}
-		},
-		"extsprintf": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-		},
-		"fancy-log": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-			"requires": {
-				"ansi-gray": "0.1.1",
-				"color-support": "1.1.3",
-				"time-stamp": "1.1.0"
-			}
-		},
-		"faye-websocket": {
-			"version": "0.7.3",
-			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
-			"integrity": "sha1-zEB0x/Sk39A69U3WXDVLE1EyzhE=",
-			"requires": {
-				"websocket-driver": "0.7.0"
-			}
-		},
-		"figures": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-			"requires": {
-				"escape-string-regexp": "1.0.5",
-				"object-assign": "4.1.1"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
-		},
-		"fill-range": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1",
-				"to-regex-range": "2.1.1"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "0.1.1"
-					}
-				}
-			}
-		},
-		"filled-array": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
-			"integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
-		},
-		"finalhandler": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz",
-			"integrity": "sha1-6VCKvs6bbbqHGmlCodeRG5GRGsc=",
-			"requires": {
-				"debug": "2.2.0",
-				"escape-html": "1.0.3",
-				"on-finished": "2.3.0",
-				"statuses": "1.3.1",
-				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-				},
-				"statuses": {
-					"version": "1.3.1",
-					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-					"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
-				}
-			}
-		},
-		"find-index": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
-			"integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
-		},
-		"find-up": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
-			}
-		},
-		"findup-sync": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-			"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
-			"requires": {
-				"detect-file": "1.0.0",
-				"is-glob": "3.1.0",
-				"micromatch": "3.1.10",
-				"resolve-dir": "1.0.1"
-			}
-		},
-		"fined": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-			"integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
-			"requires": {
-				"expand-tilde": "2.0.2",
-				"is-plain-object": "2.0.4",
-				"object.defaults": "1.1.0",
-				"object.pick": "1.3.0",
-				"parse-filepath": "1.0.2"
-			}
-		},
-		"first-chunk-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-			"integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
-		},
-		"flagged-respawn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-			"integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
-		},
-		"follow-redirects": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-			"integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
-			"requires": {
-				"debug": "3.1.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				}
-			}
-		},
-		"for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-		},
-		"for-own": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-			"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-			"requires": {
-				"for-in": "1.0.2"
-			}
-		},
-		"forever-agent": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-		},
-		"fork-stream": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
-			"integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA="
-		},
-		"form-data": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.6",
-				"mime-types": "2.1.18"
-			}
-		},
-		"fragment-cache": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-			"requires": {
-				"map-cache": "0.2.2"
-			}
-		},
-		"fresh": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
-		},
-		"from": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
-			"integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
-		},
-		"from2": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.5"
-			}
-		},
-		"fs-extra": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
-			"integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"jsonfile": "2.4.0",
-				"path-is-absolute": "1.0.1",
-				"rimraf": "2.6.2"
-			}
-		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-		},
-		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-			"optional": true,
-			"requires": {
-				"nan": "2.10.0",
-				"node-pre-gyp": "0.10.0"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true,
-					"optional": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.3.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"debug": {
-					"version": "2.6.9",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"deep-extend": {
-					"version": "0.5.1",
-					"bundled": true,
-					"optional": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"fs-minipass": {
-					"version": "1.2.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "2.2.4"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"aproba": "1.2.0",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"glob": {
-					"version": "7.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"iconv-lite": {
-					"version": "0.4.21",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safer-buffer": "2.1.2"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minimatch": "3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
-					}
-				},
-				"inherits": {
-					"version": "2.0.3",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true,
-					"optional": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "1.0.1"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "1.1.11"
-					}
-				},
-				"minimist": {
-					"version": "0.0.8",
-					"bundled": true
-				},
-				"minipass": {
-					"version": "2.2.4",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
-					}
-				},
-				"minizlib": {
-					"version": "1.1.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"minipass": "2.2.4"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					}
-				},
-				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"needle": {
-					"version": "2.2.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"debug": "2.6.9",
-						"iconv-lite": "0.4.21",
-						"sax": "1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.10.0",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"detect-libc": "1.0.3",
-						"mkdirp": "0.5.1",
-						"needle": "2.2.0",
-						"nopt": "4.0.1",
-						"npm-packlist": "1.1.10",
-						"npmlog": "4.1.2",
-						"rc": "1.2.7",
-						"rimraf": "2.6.2",
-						"semver": "5.5.0",
-						"tar": "4.4.1"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"abbrev": "1.1.1",
-						"osenv": "0.1.5"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.3",
-					"bundled": true,
-					"optional": true
-				},
-				"npm-packlist": {
-					"version": "1.1.10",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"ignore-walk": "3.0.1",
-						"npm-bundled": "1.0.3"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true,
-					"optional": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1.0.2"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"rc": {
-					"version": "1.2.7",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"deep-extend": "0.5.1",
-						"ini": "1.3.5",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "1.2.0",
-							"bundled": true,
-							"optional": true
-						}
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "2.0.0",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.1.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"rimraf": {
-					"version": "2.6.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"glob": "7.1.2"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.1",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true,
-					"optional": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true,
-					"optional": true
-				},
-				"semver": {
-					"version": "5.5.0",
-					"bundled": true,
-					"optional": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true,
-					"optional": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.1.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "2.1.1"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true,
-					"optional": true
-				},
-				"tar": {
-					"version": "4.4.1",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"chownr": "1.0.1",
-						"fs-minipass": "1.2.5",
-						"minipass": "2.2.4",
-						"minizlib": "1.1.0",
-						"mkdirp": "0.5.1",
-						"safe-buffer": "5.1.1",
-						"yallist": "3.0.2"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true,
-					"optional": true
-				},
-				"wide-align": {
-					"version": "1.1.2",
-					"bundled": true,
-					"optional": true,
-					"requires": {
-						"string-width": "1.0.2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"yallist": {
-					"version": "3.0.2",
-					"bundled": true
-				}
-			}
-		},
-		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"inherits": "2.0.3",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2"
-			}
-		},
-		"gauge": {
-			"version": "2.7.4",
-			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"requires": {
-				"aproba": "1.2.0",
-				"console-control-strings": "1.1.0",
-				"has-unicode": "2.0.1",
-				"object-assign": "4.1.1",
-				"signal-exit": "3.0.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"wide-align": "1.1.2"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"gaze": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
-			"integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
-			"requires": {
-				"globule": "0.1.0"
-			}
-		},
-		"generate-function": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-			"integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
-		},
-		"generate-object-property": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-			"requires": {
-				"is-property": "1.0.2"
-			}
-		},
-		"get-caller-file": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-			"integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
-		},
-		"get-stdin": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-			"integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-		},
-		"get-stream": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
-		},
-		"get-value": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-		},
-		"getpass": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
-				"assert-plus": "1.0.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
-		},
-		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
-			}
-		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				}
-			}
-		},
-		"glob-parent": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"requires": {
-				"is-glob": "2.0.1"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				}
-			}
-		},
-		"glob-stream": {
-			"version": "3.1.18",
-			"resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
-			"integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
-			"requires": {
-				"glob": "4.5.3",
-				"glob2base": "0.0.12",
-				"minimatch": "2.0.10",
-				"ordered-read-streams": "0.1.0",
-				"through2": "0.6.5",
-				"unique-stream": "1.0.0"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "4.5.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-					"integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "2.0.10",
-						"once": "1.4.0"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"minimatch": {
-					"version": "2.0.10",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-					"requires": {
-						"brace-expansion": "1.1.11"
-					}
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
-					}
-				}
-			}
-		},
-		"glob-watcher": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
-			"integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
-			"requires": {
-				"gaze": "0.5.2"
-			}
-		},
-		"glob2base": {
-			"version": "0.0.12",
-			"resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
-			"integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
-			"requires": {
-				"find-index": "0.1.1"
-			}
-		},
-		"global-modules": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
-			"integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-			"requires": {
-				"global-prefix": "1.0.2",
-				"is-windows": "1.0.2",
-				"resolve-dir": "1.0.1"
-			}
-		},
-		"global-prefix": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
-			"integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-			"requires": {
-				"expand-tilde": "2.0.2",
-				"homedir-polyfill": "1.0.1",
-				"ini": "1.3.5",
-				"is-windows": "1.0.2",
-				"which": "1.3.0"
-			}
-		},
-		"globby": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
-			"integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
-			"requires": {
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"glob": "6.0.4",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "6.0.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"globule": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
-			"integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
-			"requires": {
-				"glob": "3.1.21",
-				"lodash": "1.0.2",
-				"minimatch": "0.2.14"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "3.1.21",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
-					"integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
-					"requires": {
-						"graceful-fs": "1.2.3",
-						"inherits": "1.0.2",
-						"minimatch": "0.2.14"
-					}
-				},
-				"graceful-fs": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-					"integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
-				},
-				"inherits": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
-					"integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
-				},
-				"lodash": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
-					"integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
-				},
-				"lru-cache": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-					"integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-				},
-				"minimatch": {
-					"version": "0.2.14",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-					"integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-					"requires": {
-						"lru-cache": "2.7.3",
-						"sigmund": "1.0.1"
-					}
-				}
-			}
-		},
-		"glogg": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-			"requires": {
-				"sparkles": "1.0.0"
-			}
-		},
-		"gogo-shell": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/gogo-shell/-/gogo-shell-0.0.5.tgz",
-			"integrity": "sha1-o3U5wDvym29jfbvK+aTTRPAWZwc=",
-			"requires": {
-				"bluebird": "3.5.1",
-				"lodash": "4.17.5"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-				}
-			}
-		},
-		"gogo-shell-helper": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/gogo-shell-helper/-/gogo-shell-helper-0.0.8.tgz",
-			"integrity": "sha1-zxAH5+/bzB000fSqR9qjh1Ly3U0=",
-			"dev": true,
-			"requires": {
-				"lodash": "4.17.5"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-					"dev": true
-				}
-			}
-		},
-		"got": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
-			"integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-			"requires": {
-				"create-error-class": "3.0.2",
-				"duplexer2": "0.1.4",
-				"is-redirect": "1.0.0",
-				"is-retry-allowed": "1.1.0",
-				"is-stream": "1.1.0",
-				"lowercase-keys": "1.0.0",
-				"node-status-codes": "1.0.0",
-				"object-assign": "4.1.1",
-				"parse-json": "2.2.0",
-				"pinkie-promise": "2.0.1",
-				"read-all-stream": "3.1.0",
-				"readable-stream": "2.3.5",
-				"timed-out": "3.1.3",
-				"unzip-response": "1.0.2",
-				"url-parse-lax": "1.0.0"
-			},
-			"dependencies": {
-				"duplexer2": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-					"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-					"requires": {
-						"readable-stream": "2.3.5"
-					}
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"graceful-fs": {
-			"version": "4.1.11",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-		},
-		"gulp": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
-			"integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
-			"requires": {
-				"archy": "1.0.0",
-				"chalk": "1.1.3",
-				"deprecated": "0.0.1",
-				"gulp-util": "3.0.8",
-				"interpret": "1.1.0",
-				"liftoff": "2.5.0",
-				"minimist": "1.2.0",
-				"orchestrator": "0.3.8",
-				"pretty-hrtime": "1.0.3",
-				"semver": "4.3.6",
-				"tildify": "1.2.0",
-				"v8flags": "2.1.1",
-				"vinyl-fs": "0.3.14"
-			}
-		},
-		"gulp-concat": {
-			"version": "2.6.1",
-			"resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
-			"integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
-			"requires": {
-				"concat-with-sourcemaps": "1.0.5",
-				"through2": "2.0.3",
-				"vinyl": "2.1.0"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-					"integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
-				},
-				"clone-stats": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-					"integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
-				},
-				"replace-ext": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-					"integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
-				},
-				"vinyl": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-					"integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
-					"requires": {
-						"clone": "2.1.1",
-						"clone-buffer": "1.0.0",
-						"clone-stats": "1.0.0",
-						"cloneable-readable": "1.1.2",
-						"remove-trailing-separator": "1.1.0",
-						"replace-ext": "1.0.0"
-					}
-				}
-			}
-		},
-		"gulp-debug": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.1.2.tgz",
-			"integrity": "sha1-L1/l9kvNH0zxicFg4IDIrQZUMJQ=",
-			"requires": {
-				"chalk": "1.1.3",
-				"gulp-util": "3.0.8",
-				"object-assign": "4.1.1",
-				"plur": "2.1.2",
-				"stringify-object": "2.4.0",
-				"through2": "2.0.3",
-				"tildify": "1.2.0"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"gulp-filter": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-2.0.2.tgz",
-			"integrity": "sha1-HOsdET7plCzt1J9YY7Qr5EvHzSw=",
-			"requires": {
-				"gulp-util": "3.0.8",
-				"merge-stream": "0.1.8",
-				"multimatch": "2.1.0",
-				"plexer": "0.0.3",
-				"through2": "0.6.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
-					}
-				}
-			}
-		},
-		"gulp-help": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.6.1.tgz",
-			"integrity": "sha1-Jh2xhuGDl/7z9qLCLpwxW/qIrgw=",
-			"requires": {
-				"chalk": "1.1.3",
-				"object-assign": "3.0.0"
-			}
-		},
-		"gulp-if": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
-			"integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
-			"requires": {
-				"gulp-match": "1.0.3",
-				"ternary-stream": "2.0.1",
-				"through2": "2.0.3"
-			}
-		},
-		"gulp-inject": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/gulp-inject/-/gulp-inject-2.2.0.tgz",
-			"integrity": "sha1-QN/REAW69rkYHvp3awf9S1JJZJY=",
-			"requires": {
-				"event-stream": "3.3.4",
-				"gulp-util": "3.0.8"
-			}
-		},
-		"gulp-insert": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/gulp-insert/-/gulp-insert-0.5.0.tgz",
-			"integrity": "sha1-MjE/E+SiPPWsylzl8MCAkjx3hgI=",
-			"requires": {
-				"readable-stream": "1.1.14",
-				"streamqueue": "0.0.6"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
-			}
-		},
-		"gulp-liferay-r2-css": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/gulp-liferay-r2-css/-/gulp-liferay-r2-css-0.0.2.tgz",
-			"integrity": "sha1-HSVfV/uu6j0wAtXX6Qvq2lEk32c=",
-			"requires": {
-				"gulp-util": "3.0.8",
-				"liferay-r2": "0.4.4",
-				"through2": "2.0.3"
-			}
-		},
-		"gulp-livereload": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
-			"integrity": "sha1-APdEstdJ0+njdGWJyKRKysd5tQ8=",
-			"requires": {
-				"chalk": "0.5.1",
-				"debug": "2.6.9",
-				"event-stream": "3.3.4",
-				"gulp-util": "3.0.8",
-				"lodash.assign": "3.2.0",
-				"mini-lr": "0.1.9"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-				},
-				"ansi-styles": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-					"integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-				},
-				"chalk": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-					"requires": {
-						"ansi-styles": "1.1.0",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "0.1.0",
-						"strip-ansi": "0.3.0",
-						"supports-color": "0.2.0"
-					}
-				},
-				"has-ansi": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-					"requires": {
-						"ansi-regex": "0.2.1"
-					}
-				},
-				"strip-ansi": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-					"requires": {
-						"ansi-regex": "0.2.1"
-					}
-				},
-				"supports-color": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-					"integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-				}
-			}
-		},
-		"gulp-load-plugins": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-0.8.1.tgz",
-			"integrity": "sha1-CoJh0Fnf3ckY/aQGyCMucvo00uo=",
-			"requires": {
-				"findup-sync": "0.2.1",
-				"multimatch": "2.0.0"
-			},
-			"dependencies": {
-				"findup-sync": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-					"integrity": "sha1-4KkKRQB1xJRm7lE3MgV1FLgeh4w=",
-					"requires": {
-						"glob": "4.3.5"
-					}
-				},
-				"glob": {
-					"version": "4.3.5",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-					"integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "2.0.10",
-						"once": "1.4.0"
-					}
-				},
-				"minimatch": {
-					"version": "2.0.10",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-					"requires": {
-						"brace-expansion": "1.1.11"
-					}
-				},
-				"multimatch": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
-					"integrity": "sha1-xa2kJTV7dEulSELr3OHI8L5UK28=",
-					"requires": {
-						"array-differ": "1.0.0",
-						"array-union": "1.0.2",
-						"minimatch": "2.0.10"
-					}
-				}
-			}
-		},
-		"gulp-match": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
-			"integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
-			"requires": {
-				"minimatch": "3.0.4"
-			}
-		},
-		"gulp-plumber": {
-			"version": "0.6.6",
-			"resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-0.6.6.tgz",
-			"integrity": "sha1-n5hGpRPHDQMhbOeiqM5v1aP8MXU=",
-			"requires": {
-				"gulp-util": "3.0.8",
-				"through2": "0.6.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
-					}
-				}
-			}
-		},
-		"gulp-prompt": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/gulp-prompt/-/gulp-prompt-0.1.2.tgz",
-			"integrity": "sha1-BsmZvedk4++sYCJTbMK7Aiq4N1A=",
-			"requires": {
-				"event-stream": "3.0.20",
-				"inquirer": "0.3.5"
-			},
-			"dependencies": {
-				"async": {
-					"version": "0.2.10",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
-				},
-				"event-stream": {
-					"version": "3.0.20",
-					"resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
-					"integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
-					"requires": {
-						"duplexer": "0.1.1",
-						"from": "0.1.7",
-						"map-stream": "0.0.7",
-						"pause-stream": "0.0.11",
-						"split": "0.2.10",
-						"stream-combiner": "0.0.4",
-						"through": "2.3.8"
-					}
-				},
-				"inquirer": {
-					"version": "0.3.5",
-					"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.3.5.tgz",
-					"integrity": "sha1-p4vgZKyavxaBR8Ahaakx2aSDqfY=",
-					"requires": {
-						"async": "0.2.10",
-						"cli-color": "0.2.3",
-						"lodash": "1.2.1",
-						"mute-stream": "0.0.3"
-					}
-				},
-				"lodash": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-1.2.1.tgz",
-					"integrity": "sha1-7UexbkbwaytAMJto6RY8F+k+owQ="
-				},
-				"map-stream": {
-					"version": "0.0.7",
-					"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-					"integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
-				},
-				"split": {
-					"version": "0.2.10",
-					"resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
-					"integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
-					"requires": {
-						"through": "2.3.8"
-					}
-				}
-			}
-		},
-		"gulp-rename": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
-			"integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc="
-		},
-		"gulp-replace-task": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/gulp-replace-task/-/gulp-replace-task-0.2.3.tgz",
-			"integrity": "sha1-Qy8kJkrP7T0hBdSpRbBMiqh8CJk=",
-			"requires": {
-				"applause": "0.4.3",
-				"gulp-util": "3.0.8",
-				"through2": "2.0.3"
-			}
-		},
-		"gulp-ruby-sass": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/gulp-ruby-sass/-/gulp-ruby-sass-2.1.1.tgz",
-			"integrity": "sha1-6A9lCSEI7kr8tJNgiNxyUzaa3Kw=",
-			"requires": {
-				"convert-source-map": "1.5.1",
-				"cross-spawn": "5.1.0",
-				"dargs": "2.1.0",
-				"each-async": "1.1.1",
-				"escape-string-regexp": "1.0.5",
-				"glob": "7.1.2",
-				"glob2base": "0.0.12",
-				"gulp-util": "3.0.8",
-				"md5-hex": "1.3.0",
-				"object-assign": "4.1.1",
-				"os-tmpdir": "1.0.2",
-				"path-exists": "2.1.0",
-				"rimraf": "2.6.2"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-					"requires": {
-						"lru-cache": "4.1.2",
-						"shebang-command": "1.2.0",
-						"which": "1.3.0"
-					}
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"gulp-sass": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
-			"integrity": "sha1-U9xLaKH13f5EJKtMJHZVJpqLdLc=",
-			"dev": true,
-			"requires": {
-				"gulp-util": "3.0.8",
-				"lodash.clonedeep": "4.5.0",
-				"node-sass": "4.7.2",
-				"through2": "2.0.3",
-				"vinyl-sourcemaps-apply": "0.2.1"
-			}
-		},
-		"gulp-sourcemaps": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
-			"requires": {
-				"convert-source-map": "1.5.1",
-				"graceful-fs": "4.1.11",
-				"strip-bom": "2.0.0",
-				"through2": "2.0.3",
-				"vinyl": "1.2.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				},
-				"vinyl": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
-					"requires": {
-						"clone": "1.0.3",
-						"clone-stats": "0.0.1",
-						"replace-ext": "0.0.1"
-					}
-				}
-			}
-		},
-		"gulp-storage": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/gulp-storage/-/gulp-storage-1.0.6.tgz",
-			"integrity": "sha1-FmjuOaK8877vbStrfW1tM0X0Etc=",
-			"requires": {
-				"gulp": "3.9.1",
-				"gulp-util": "2.2.20",
-				"lodash": "2.4.2",
-				"through2": "2.0.3"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-					"integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-				},
-				"ansi-styles": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-					"integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-				},
-				"chalk": {
-					"version": "0.5.1",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-					"integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-					"requires": {
-						"ansi-styles": "1.1.0",
-						"escape-string-regexp": "1.0.5",
-						"has-ansi": "0.1.0",
-						"strip-ansi": "0.3.0",
-						"supports-color": "0.2.0"
-					}
-				},
-				"dateformat": {
-					"version": "1.0.12",
-					"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
-					"integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
-					"requires": {
-						"get-stdin": "4.0.1",
-						"meow": "3.7.0"
-					}
-				},
-				"gulp-util": {
-					"version": "2.2.20",
-					"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
-					"integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
-					"requires": {
-						"chalk": "0.5.1",
-						"dateformat": "1.0.12",
-						"lodash._reinterpolate": "2.4.1",
-						"lodash.template": "2.4.1",
-						"minimist": "0.2.0",
-						"multipipe": "0.1.2",
-						"through2": "0.5.1",
-						"vinyl": "0.2.3"
-					},
-					"dependencies": {
-						"through2": {
-							"version": "0.5.1",
-							"resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
-							"integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
-							"requires": {
-								"readable-stream": "1.0.34",
-								"xtend": "3.0.0"
-							}
-						}
-					}
-				},
-				"has-ansi": {
-					"version": "0.1.0",
-					"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-					"integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-					"requires": {
-						"ansi-regex": "0.2.1"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"lodash": {
-					"version": "2.4.2",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-					"integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
-				},
-				"lodash._reinterpolate": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
-					"integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
-				},
-				"lodash.escape": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
-					"integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
-					"requires": {
-						"lodash._escapehtmlchar": "2.4.1",
-						"lodash._reunescapedhtml": "2.4.1",
-						"lodash.keys": "2.4.1"
-					}
-				},
-				"lodash.keys": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-					"requires": {
-						"lodash._isnative": "2.4.1",
-						"lodash._shimkeys": "2.4.1",
-						"lodash.isobject": "2.4.1"
-					}
-				},
-				"lodash.template": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
-					"integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
-					"requires": {
-						"lodash._escapestringchar": "2.4.1",
-						"lodash._reinterpolate": "2.4.1",
-						"lodash.defaults": "2.4.1",
-						"lodash.escape": "2.4.1",
-						"lodash.keys": "2.4.1",
-						"lodash.templatesettings": "2.4.1",
-						"lodash.values": "2.4.1"
-					}
-				},
-				"lodash.templatesettings": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
-					"integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
-					"requires": {
-						"lodash._reinterpolate": "2.4.1",
-						"lodash.escape": "2.4.1"
-					}
-				},
-				"minimist": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
-					"integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"strip-ansi": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-					"integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-					"requires": {
-						"ansi-regex": "0.2.1"
-					}
-				},
-				"supports-color": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-					"integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-				},
-				"vinyl": {
-					"version": "0.2.3",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
-					"integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
-					"requires": {
-						"clone-stats": "0.0.1"
-					}
-				},
-				"xtend": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
-					"integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
-				}
-			}
-		},
-		"gulp-util": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-			"requires": {
-				"array-differ": "1.0.0",
-				"array-uniq": "1.0.3",
-				"beeper": "1.1.1",
-				"chalk": "1.1.3",
-				"dateformat": "2.2.0",
-				"fancy-log": "1.3.2",
-				"gulplog": "1.0.0",
-				"has-gulplog": "0.1.0",
-				"lodash._reescape": "3.0.0",
-				"lodash._reevaluate": "3.0.0",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.template": "3.6.2",
-				"minimist": "1.2.0",
-				"multipipe": "0.1.2",
-				"object-assign": "3.0.0",
-				"replace-ext": "0.0.1",
-				"through2": "2.0.3",
-				"vinyl": "0.5.3"
-			}
-		},
-		"gulp-zip": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/gulp-zip/-/gulp-zip-3.2.0.tgz",
-			"integrity": "sha1-69GY2ubcLV9E2BRWnI7EIRipPvk=",
-			"requires": {
-				"chalk": "1.1.3",
-				"concat-stream": "1.6.2",
-				"gulp-util": "3.0.8",
-				"through2": "2.0.3",
-				"yazl": "2.4.3"
-			}
-		},
-		"gulplog": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-			"requires": {
-				"glogg": "1.0.1"
-			}
-		},
-		"handlebars": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
-			"integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
-			"requires": {
-				"optimist": "0.6.1",
-				"source-map": "0.1.43",
-				"uglify-js": "2.3.6"
-			}
-		},
-		"har-validator": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-			"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-			"requires": {
-				"chalk": "1.1.3",
-				"commander": "2.15.1",
-				"is-my-json-valid": "2.17.2",
-				"pinkie-promise": "2.0.1"
-			}
-		},
-		"has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
-		},
-		"has-binary2": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-			"integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-			"requires": {
-				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-				}
-			}
-		},
-		"has-cors": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-			"integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-		},
-		"has-gulplog": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-			"requires": {
-				"sparkles": "1.0.0"
-			}
-		},
-		"has-symbol-support-x": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-			"integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
-		},
-		"has-to-string-tag-x": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-			"integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-			"requires": {
-				"has-symbol-support-x": "1.4.2"
-			}
-		},
-		"has-unicode": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
-		},
-		"has-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-			"requires": {
-				"get-value": "2.0.6",
-				"has-values": "1.0.0",
-				"isobject": "3.0.1"
-			}
-		},
-		"has-values": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"hawk": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"requires": {
-				"boom": "2.10.1",
-				"cryptiles": "2.0.5",
-				"hoek": "2.16.3",
-				"sntp": "1.0.9"
-			}
-		},
-		"hoek": {
-			"version": "2.16.3",
-			"resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-			"integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-		},
-		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-			"requires": {
-				"parse-passwd": "1.0.0"
-			}
-		},
-		"hosted-git-info": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-			"integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
-		},
-		"http-cache-semantics": {
-			"version": "3.8.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-			"integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
-		},
-		"http-errors": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-			"integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-			"requires": {
-				"inherits": "2.0.3",
-				"statuses": "1.4.0"
-			}
-		},
-		"http-parser-js": {
-			"version": "0.4.11",
-			"resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
-			"integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA=="
-		},
-		"http-proxy": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
-			"integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
-			"requires": {
-				"eventemitter3": "1.2.0",
-				"requires-port": "1.0.0"
-			}
-		},
-		"http-signature": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-			"requires": {
-				"assert-plus": "0.2.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.14.1"
-			}
-		},
-		"iconv-lite": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-			"integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
-		},
-		"immutable": {
-			"version": "3.8.2",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-			"integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
-		},
-		"imurmurhash": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-		},
-		"in-publish": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
-			"integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
-		},
-		"indent-string": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"requires": {
-				"repeating": "2.0.1"
-			}
-		},
-		"indexof": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-			"integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
-			}
-		},
-		"inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-		},
-		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-		},
-		"inquirer": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-			"requires": {
-				"ansi-escapes": "1.4.0",
-				"ansi-regex": "2.1.1",
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-width": "2.2.0",
-				"figures": "1.7.0",
-				"lodash": "4.17.5",
-				"readline2": "1.0.1",
-				"run-async": "0.1.0",
-				"rx-lite": "3.1.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"through": "2.3.8"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-				}
-			}
-		},
-		"interpret": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
-		},
-		"into-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-			"integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
-			"requires": {
-				"from2": "2.3.0",
-				"p-is-promise": "1.1.0"
-			}
-		},
-		"invert-kv": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
-		},
-		"irregular-plurals": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-			"integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
-		},
-		"is-absolute": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-			"integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-			"requires": {
-				"is-relative": "1.0.0",
-				"is-windows": "1.0.2"
-			}
-		},
-		"is-accessor-descriptor": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
-			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-			"requires": {
-				"kind-of": "3.2.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"is-arrayish": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-		},
-		"is-binary-path": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"requires": {
-				"binary-extensions": "1.11.0"
-			}
-		},
-		"is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-		},
-		"is-builtin-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"requires": {
-				"builtin-modules": "1.1.1"
-			}
-		},
-		"is-data-descriptor": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
-			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-			"requires": {
-				"kind-of": "3.2.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"is-descriptor": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-			"requires": {
-				"is-accessor-descriptor": "0.1.6",
-				"is-data-descriptor": "0.1.4",
-				"kind-of": "5.1.0"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
-				}
-			}
-		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"requires": {
-				"is-primitive": "2.0.0"
-			}
-		},
-		"is-extendable": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
-		},
-		"is-extglob": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-		},
-		"is-finite": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
-		},
-		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
-		},
-		"is-glob": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-			"requires": {
-				"is-extglob": "2.1.1"
-			}
-		},
-		"is-my-ip-valid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
-		},
-		"is-my-json-valid": {
-			"version": "2.17.2",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"is-my-ip-valid": "1.0.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
-			}
-		},
-		"is-npm": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-			"integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-		},
-		"is-number": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-			"requires": {
-				"kind-of": "3.2.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"is-number-like": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
-			"integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
-			"requires": {
-				"lodash.isfinite": "3.3.2"
-			}
-		},
-		"is-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-			"integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
-		},
-		"is-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-			"integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-		},
-		"is-odd": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-			"requires": {
-				"is-number": "4.0.0"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-				}
-			}
-		},
-		"is-path-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
-		},
-		"is-path-in-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-			"requires": {
-				"is-path-inside": "1.0.1"
-			}
-		},
-		"is-path-inside": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-			"requires": {
-				"path-is-inside": "1.0.2"
-			}
-		},
-		"is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-		},
-		"is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"requires": {
-				"isobject": "3.0.1"
-			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
-		},
-		"is-property": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
-		},
-		"is-redirect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
-		},
-		"is-regexp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-			"integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
-		},
-		"is-relative": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-			"integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-			"requires": {
-				"is-unc-path": "1.0.0"
-			}
-		},
-		"is-retry-allowed": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-			"integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
-		},
-		"is-stream": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-		},
-		"is-typedarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-		},
-		"is-unc-path": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-			"integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-			"requires": {
-				"unc-path-regex": "0.1.2"
-			}
-		},
-		"is-utf8": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
-		},
-		"is-windows": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-		},
-		"isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-		},
-		"isstream": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-		},
-		"isurl": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-			"integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-			"requires": {
-				"has-to-string-tag-x": "1.4.1",
-				"is-object": "1.0.1"
-			}
-		},
-		"js-base64": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-			"integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
-		},
-		"js-yaml": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-			"integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
-			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "4.0.0"
-			}
-		},
-		"jsbn": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"optional": true
-		},
-		"json-buffer": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-			"integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
-		},
-		"json-schema": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-		},
-		"json-stringify-safe": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-		},
-		"jsonfile": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-			"requires": {
-				"graceful-fs": "4.1.11"
-			}
-		},
-		"jsonpointer": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-			"integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
-		},
-		"jsprim": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"extsprintf": "1.3.0",
-				"json-schema": "0.2.3",
-				"verror": "1.10.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
-		},
-		"keyv": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-			"integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
-			"requires": {
-				"json-buffer": "3.0.0"
-			}
-		},
-		"kind-of": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-			"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-		},
-		"latest-version": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
-			"integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-			"requires": {
-				"package-json": "2.4.0"
-			},
-			"dependencies": {
-				"package-json": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
-					"integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-					"requires": {
-						"got": "5.7.1",
-						"registry-auth-token": "3.3.2",
-						"registry-url": "3.1.0",
-						"semver": "5.5.0"
-					}
-				},
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-				}
-			}
-		},
-		"lazy-req": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
-			"integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
-		},
-		"lcid": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"requires": {
-				"invert-kv": "1.0.0"
-			}
-		},
-		"liferay-css-parse": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/liferay-css-parse/-/liferay-css-parse-1.7.1.tgz",
-			"integrity": "sha1-wHUMwPBkXSGQ7u/uhFtvyxVPPkU="
-		},
-		"liferay-frontend-common-css": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-common-css/-/liferay-frontend-common-css-1.0.4.tgz",
-			"integrity": "sha1-5Nc+QGAg2QfJCbyssnAKUvocfxY="
-		},
-		"liferay-frontend-theme-classic-web": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-classic-web/-/liferay-frontend-theme-classic-web-2.0.2.tgz",
-			"integrity": "sha1-mFrY147m7HwOX6YaFGXc76NuG1o="
-		},
-		"liferay-frontend-theme-styled": {
-			"version": "2.0.28",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.28.tgz",
-			"integrity": "sha1-IQx2gcjHhScwHcdk3GhS11C6Crg="
-		},
-		"liferay-frontend-theme-unstyled": {
-			"version": "2.1.16",
-			"resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.1.16.tgz",
-			"integrity": "sha1-KPaqFP1DqDfSwYpcKe5p8g1vdeo="
-		},
-		"liferay-plugin-node-tasks": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/liferay-plugin-node-tasks/-/liferay-plugin-node-tasks-1.0.11.tgz",
-			"integrity": "sha1-gs8ADbkfpO44/x1HDvSNVQp9Uxw=",
-			"requires": {
-				"async": "2.6.0",
-				"gogo-shell": "0.0.5",
-				"gulp": "3.9.1",
-				"gulp-help": "1.6.1",
-				"gulp-storage": "1.0.6",
-				"gulp-util": "3.0.8",
-				"gulp-zip": "3.2.0",
-				"inquirer": "0.12.0",
-				"lodash": "4.17.5",
-				"minimist": "1.2.0",
-				"require-directory": "2.1.1",
-				"run-sequence": "1.2.2"
-			},
-			"dependencies": {
-				"async": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-					"requires": {
-						"lodash": "4.17.5"
-					}
-				},
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-				}
-			}
-		},
-		"liferay-r2": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/liferay-r2/-/liferay-r2-0.4.4.tgz",
-			"integrity": "sha1-zAAFnv37icywIk603cfyc53EJ/s=",
-			"requires": {
-				"css-stringify": "1.4.1",
-				"liferay-css-parse": "1.7.1"
-			}
-		},
-		"liferay-theme-deps-7.0": {
-			"version": "8.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/liferay-theme-deps-7.0/-/liferay-theme-deps-7.0-8.0.0-beta.0.tgz",
-			"integrity": "sha512-hhna5QGO3ZbxhdhQKI6QVDVwLOJ//mENYrhC/nbb3kS51Ohuu1dqJ6LshVFwoIA+bz6BueMfGVZrxRjoV9K/8w==",
-			"requires": {
-				"compass-mixins": "0.12.10",
-				"gulp-ruby-sass": "2.1.1",
-				"gulp-sass": "3.2.0",
-				"liferay-frontend-common-css": "1.0.4",
-				"liferay-frontend-theme-classic-web": "2.0.2",
-				"liferay-frontend-theme-styled": "2.0.28",
-				"liferay-frontend-theme-unstyled": "2.1.16",
-				"liferay-theme-deps-normalize": "8.0.0-beta.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-					"requires": {
-						"lru-cache": "4.1.2",
-						"which": "1.3.0"
-					}
-				},
-				"gaze": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-					"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-					"requires": {
-						"globule": "1.2.1"
-					}
-				},
-				"globule": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-					"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-					"requires": {
-						"glob": "7.1.2",
-						"lodash": "4.17.10",
-						"minimatch": "3.0.4"
-					}
-				},
-				"gulp-sass": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.2.0.tgz",
-					"integrity": "sha512-lIF2rC8LejqVLw5lnL7efLWjOrir/n87icopRNxOMCfz9rE52IXUP9Bgxt/OAWzIsBbNSjVWlbxaHtjDFnPhfQ==",
-					"requires": {
-						"gulp-util": "3.0.8",
-						"lodash.clonedeep": "4.5.0",
-						"node-sass": "4.9.0",
-						"through2": "2.0.3",
-						"vinyl-sourcemaps-apply": "0.2.1"
-					}
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				},
-				"lodash.assign": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-					"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-				},
-				"node-sass": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-					"integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
-					"requires": {
-						"async-foreach": "0.1.3",
-						"chalk": "1.1.3",
-						"cross-spawn": "3.0.1",
-						"gaze": "1.1.3",
-						"get-stdin": "4.0.1",
-						"glob": "7.1.2",
-						"in-publish": "2.0.0",
-						"lodash.assign": "4.2.0",
-						"lodash.clonedeep": "4.5.0",
-						"lodash.mergewith": "4.6.1",
-						"meow": "3.7.0",
-						"mkdirp": "0.5.1",
-						"nan": "2.10.0",
-						"node-gyp": "3.6.2",
-						"npmlog": "4.1.2",
-						"request": "2.79.0",
-						"sass-graph": "2.2.4",
-						"stdout-stream": "1.4.0",
-						"true-case-path": "1.0.2"
-					}
-				}
-			}
-		},
-		"liferay-theme-deps-7.1": {
-			"version": "8.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/liferay-theme-deps-7.1/-/liferay-theme-deps-7.1-8.0.0-beta.0.tgz",
-			"integrity": "sha512-uXClSzlEmZUPy8Bt4oH7JBzGdScRq/a/TMFVi326tGm1KRJS55sAbhglcIXNSLsw07lqSCjxLQV5IIyNpZxQ0w==",
-			"requires": {
-				"compass-mixins": "0.12.10",
-				"gulp-ruby-sass": "2.1.1",
-				"gulp-sass": "3.2.0",
-				"liferay-frontend-common-css": "1.0.4",
-				"liferay-frontend-theme-classic-web": "2.0.2",
-				"liferay-frontend-theme-styled": "3.0.0-alpha.1521181585788",
-				"liferay-frontend-theme-unstyled": "3.0.0-alpha.1521181854318",
-				"liferay-theme-deps-normalize": "1.0.0"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-					"requires": {
-						"lru-cache": "4.1.2",
-						"which": "1.3.0"
-					}
-				},
-				"gaze": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-					"integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
-					"requires": {
-						"globule": "1.2.1"
-					}
-				},
-				"globule": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-					"integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
-					"requires": {
-						"glob": "7.1.2",
-						"lodash": "4.17.10",
-						"minimatch": "3.0.4"
-					}
-				},
-				"gulp-sass": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.2.0.tgz",
-					"integrity": "sha512-lIF2rC8LejqVLw5lnL7efLWjOrir/n87icopRNxOMCfz9rE52IXUP9Bgxt/OAWzIsBbNSjVWlbxaHtjDFnPhfQ==",
-					"requires": {
-						"gulp-util": "3.0.8",
-						"lodash.clonedeep": "4.5.0",
-						"node-sass": "4.9.0",
-						"through2": "2.0.3",
-						"vinyl-sourcemaps-apply": "0.2.1"
-					}
-				},
-				"liferay-frontend-theme-styled": {
-					"version": "3.0.0-alpha.1521181585788",
-					"resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-3.0.0-alpha.1521181585788.tgz",
-					"integrity": "sha512-h9l0mN5Z+d+AZEXgGDJL3eMXaUlkiPcUha6v/Z3pUgKDo2BCnYvO6zEQxMZShpc0myNMvrILvOqRQD9oM1thow=="
-				},
-				"liferay-frontend-theme-unstyled": {
-					"version": "3.0.0-alpha.1521181854318",
-					"resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-3.0.0-alpha.1521181854318.tgz",
-					"integrity": "sha512-a2EFLyc/HXGQhpOLMNkH5gug+n70UAixu95YemiPCji9eYDY4xWfCr8UTg7H7cd/BesGMIUO/N/XgYXZLDCi1Q==",
-					"requires": {
-						"clay": "2.0.0-rc.9"
-					}
-				},
-				"liferay-theme-deps-normalize": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/liferay-theme-deps-normalize/-/liferay-theme-deps-normalize-1.0.0.tgz",
-					"integrity": "sha1-ULZ371ujG0iN8IVRBBkxZy/N3z4="
-				},
-				"lodash": {
-					"version": "4.17.10",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-					"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-				},
-				"lodash.assign": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-					"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
-				},
-				"node-sass": {
-					"version": "4.9.0",
-					"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.0.tgz",
-					"integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
-					"requires": {
-						"async-foreach": "0.1.3",
-						"chalk": "1.1.3",
-						"cross-spawn": "3.0.1",
-						"gaze": "1.1.3",
-						"get-stdin": "4.0.1",
-						"glob": "7.1.2",
-						"in-publish": "2.0.0",
-						"lodash.assign": "4.2.0",
-						"lodash.clonedeep": "4.5.0",
-						"lodash.mergewith": "4.6.1",
-						"meow": "3.7.0",
-						"mkdirp": "0.5.1",
-						"nan": "2.10.0",
-						"node-gyp": "3.6.2",
-						"npmlog": "4.1.2",
-						"request": "2.79.0",
-						"sass-graph": "2.2.4",
-						"stdout-stream": "1.4.0",
-						"true-case-path": "1.0.2"
-					}
-				}
-			}
-		},
-		"liferay-theme-deps-normalize": {
-			"version": "8.0.0-beta.0",
-			"resolved": "https://registry.npmjs.org/liferay-theme-deps-normalize/-/liferay-theme-deps-normalize-8.0.0-beta.0.tgz",
-			"integrity": "sha512-X6gE+bLHvTH+9GAu3wc54jcHZz4aEVZX1FiHQ+XLJst16TdLdKgDz9dvIZWNKcSXDHuWebliyHhtwJ75yCMpVQ=="
-		},
-		"liftoff": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-			"integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
-			"requires": {
-				"extend": "3.0.1",
-				"findup-sync": "2.0.0",
-				"fined": "1.1.0",
-				"flagged-respawn": "1.0.0",
-				"is-plain-object": "2.0.4",
-				"object.map": "1.0.1",
-				"rechoir": "0.6.2",
-				"resolve": "1.6.0"
-			}
-		},
-		"limiter": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-			"integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw=="
-		},
-		"livereload-js": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
-			"integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg=="
-		},
-		"load-json-file": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
-			},
-			"dependencies": {
-				"strip-bom": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-					"requires": {
-						"is-utf8": "0.2.1"
-					}
-				}
-			}
-		},
-		"localtunnel": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
-			"integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
-			"requires": {
-				"axios": "0.17.1",
-				"debug": "2.6.8",
-				"openurl": "1.1.1",
-				"yargs": "6.6.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				},
-				"debug": {
-					"version": "2.6.8",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-					"integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"yargs": {
-					"version": "6.6.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
-					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
-					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"requires": {
-						"camelcase": "3.0.0"
-					}
-				}
-			}
-		},
-		"lodash": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-			"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-		},
-		"lodash._baseassign": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
-			}
-		},
-		"lodash._basecopy": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-			"integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
-		},
-		"lodash._basetostring": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-			"integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
-		},
-		"lodash._basevalues": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-			"integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
-		},
-		"lodash._bindcallback": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-			"integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
-		},
-		"lodash._createassigner": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-			"integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
-			"requires": {
-				"lodash._bindcallback": "3.0.1",
-				"lodash._isiterateecall": "3.0.9",
-				"lodash.restparam": "3.6.1"
-			}
-		},
-		"lodash._escapehtmlchar": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
-			"integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
-			"requires": {
-				"lodash._htmlescapes": "2.4.1"
-			}
-		},
-		"lodash._escapestringchar": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
-			"integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I="
-		},
-		"lodash._getnative": {
-			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-			"integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
-		},
-		"lodash._htmlescapes": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
-			"integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
-		},
-		"lodash._isiterateecall": {
-			"version": "3.0.9",
-			"resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-			"integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
-		},
-		"lodash._isnative": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
-			"integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
-		},
-		"lodash._objecttypes": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
-			"integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
-		},
-		"lodash._reescape": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-			"integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
-		},
-		"lodash._reevaluate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-			"integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
-		},
-		"lodash._reinterpolate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-			"integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
-		},
-		"lodash._reunescapedhtml": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
-			"integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
-			"requires": {
-				"lodash._htmlescapes": "2.4.1",
-				"lodash.keys": "2.4.1"
-			},
-			"dependencies": {
-				"lodash.keys": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-					"requires": {
-						"lodash._isnative": "2.4.1",
-						"lodash._shimkeys": "2.4.1",
-						"lodash.isobject": "2.4.1"
-					}
-				}
-			}
-		},
-		"lodash._root": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-			"integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
-		},
-		"lodash._shimkeys": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
-			"integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
-			"requires": {
-				"lodash._objecttypes": "2.4.1"
-			}
-		},
-		"lodash.assign": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-			"integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
-			"requires": {
-				"lodash._baseassign": "3.2.0",
-				"lodash._createassigner": "3.1.1",
-				"lodash.keys": "3.1.2"
-			}
-		},
-		"lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-		},
-		"lodash.defaults": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
-			"integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
-			"requires": {
-				"lodash._objecttypes": "2.4.1",
-				"lodash.keys": "2.4.1"
-			},
-			"dependencies": {
-				"lodash.keys": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-					"requires": {
-						"lodash._isnative": "2.4.1",
-						"lodash._shimkeys": "2.4.1",
-						"lodash.isobject": "2.4.1"
-					}
-				}
-			}
-		},
-		"lodash.escape": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-			"requires": {
-				"lodash._root": "3.0.1"
-			}
-		},
-		"lodash.isarguments": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-			"integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
-		},
-		"lodash.isarray": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
-		},
-		"lodash.isfinite": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
-			"integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
-		},
-		"lodash.isobject": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
-			"integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
-			"requires": {
-				"lodash._objecttypes": "2.4.1"
-			}
-		},
-		"lodash.keys": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
-			}
-		},
-		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
-		},
-		"lodash.restparam": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
-		},
-		"lodash.template": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash._basetostring": "3.0.1",
-				"lodash._basevalues": "3.0.0",
-				"lodash._isiterateecall": "3.0.9",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0",
-				"lodash.keys": "3.1.2",
-				"lodash.restparam": "3.6.1",
-				"lodash.templatesettings": "3.1.1"
-			}
-		},
-		"lodash.templatesettings": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-			"requires": {
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0"
-			}
-		},
-		"lodash.values": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
-			"integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
-			"requires": {
-				"lodash.keys": "2.4.1"
-			},
-			"dependencies": {
-				"lodash.keys": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
-					"integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
-					"requires": {
-						"lodash._isnative": "2.4.1",
-						"lodash._shimkeys": "2.4.1",
-						"lodash.isobject": "2.4.1"
-					}
-				}
-			}
-		},
-		"loud-rejection": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
-			}
-		},
-		"lowercase-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-			"integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
-		},
-		"lru-cache": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-			"integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
-			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
-			}
-		},
-		"make-iterator": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
-			"integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
-			"requires": {
-				"kind-of": "6.0.2"
-			}
-		},
-		"map-cache": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
-		},
-		"map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-		},
-		"map-stream": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-			"integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
-		},
-		"map-visit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-			"requires": {
-				"object-visit": "1.0.1"
-			}
-		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
-		},
-		"md5-hex": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-			"integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-			"requires": {
-				"md5-o-matic": "0.1.1"
-			}
-		},
-		"md5-o-matic": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-			"integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
-		},
-		"media-typer": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-			"integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-		},
-		"memoizee": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
-			"integrity": "sha1-u0WnrQJTAILxYSZx2rNSGc0uB0E=",
-			"requires": {
-				"es5-ext": "0.9.2",
-				"event-emitter": "0.2.2",
-				"next-tick": "0.1.0"
-			}
-		},
-		"meow": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"merge-stream": {
-			"version": "0.1.8",
-			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
-			"integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
-			"requires": {
-				"through2": "0.6.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
-					}
-				}
-			}
-		},
-		"micromatch": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"braces": "2.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"extglob": "2.0.4",
-				"fragment-cache": "0.2.1",
-				"kind-of": "6.0.2",
-				"nanomatch": "1.2.9",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
-			}
-		},
-		"mime": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-			"integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-		},
-		"mime-db": {
-			"version": "1.33.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-			"integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
-		},
-		"mime-types": {
-			"version": "2.1.18",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-			"requires": {
-				"mime-db": "1.33.0"
-			}
-		},
-		"mimic-response": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.0.tgz",
-			"integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
-		},
-		"mini-lr": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz",
-			"integrity": "sha1-AhmdJzR5U9H9HW297UJh8Yey0PY=",
-			"requires": {
-				"body-parser": "1.14.2",
-				"debug": "2.6.9",
-				"faye-websocket": "0.7.3",
-				"livereload-js": "2.3.0",
-				"parseurl": "1.3.2",
-				"qs": "2.2.5"
-			}
-		},
-		"minimatch": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-			"requires": {
-				"brace-expansion": "1.1.11"
-			}
-		},
-		"minimist": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-		},
-		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-			"requires": {
-				"for-in": "1.0.2",
-				"is-extendable": "1.0.1"
-			},
-			"dependencies": {
-				"is-extendable": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-					"requires": {
-						"is-plain-object": "2.0.4"
-					}
-				}
-			}
-		},
-		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"requires": {
-				"minimist": "0.0.8"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.8",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-				}
-			}
-		},
-		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-		},
-		"multimatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
-			}
-		},
-		"multipipe": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-			"integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-			"requires": {
-				"duplexer2": "0.0.2"
-			}
-		},
-		"mute-stream": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.3.tgz",
-			"integrity": "sha1-8JwJDTM7MGP2Fcu8ynGzSYk/AVI="
-		},
-		"nan": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-		},
-		"nanomatch": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-			"requires": {
-				"arr-diff": "4.0.0",
-				"array-unique": "0.3.2",
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"fragment-cache": "0.2.1",
-				"is-odd": "2.0.0",
-				"is-windows": "1.0.2",
-				"kind-of": "6.0.2",
-				"object.pick": "1.3.0",
-				"regex-not": "1.0.2",
-				"snapdragon": "0.8.2",
-				"to-regex": "3.0.2"
-			}
-		},
-		"natives": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
-			"integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
-		},
-		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
-		},
-		"next-tick": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
-			"integrity": "sha1-GRLM6OubaX1kD7upT48A3sO5Qlk="
-		},
-		"node-bourbon": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/node-bourbon/-/node-bourbon-4.2.3.tgz",
-			"integrity": "sha1-vuEU9IBbXrK10nRHC8TTpskEnMQ=",
-			"requires": {
-				"bourbon": "4.2.3"
-			}
-		},
-		"node-gyp": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-			"integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
-			"requires": {
-				"fstream": "1.0.11",
-				"glob": "7.1.2",
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"npmlog": "4.1.2",
-				"osenv": "0.1.5",
-				"request": "2.79.0",
-				"rimraf": "2.6.2",
-				"semver": "5.3.0",
-				"tar": "2.2.1",
-				"which": "1.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-					"integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
-				}
-			}
-		},
-		"node-sass": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.7.2.tgz",
-			"integrity": "sha512-CaV+wLqZ7//Jdom5aUFCpGNoECd7BbNhjuwdsX/LkXBrHl8eb1Wjw4HvWqcFvhr5KuNgAk8i/myf/MQ1YYeroA==",
-			"dev": true,
-			"requires": {
-				"async-foreach": "0.1.3",
-				"chalk": "1.1.3",
-				"cross-spawn": "3.0.1",
-				"gaze": "1.1.2",
-				"get-stdin": "4.0.1",
-				"glob": "7.1.2",
-				"in-publish": "2.0.0",
-				"lodash.assign": "4.2.0",
-				"lodash.clonedeep": "4.5.0",
-				"lodash.mergewith": "4.6.1",
-				"meow": "3.7.0",
-				"mkdirp": "0.5.1",
-				"nan": "2.10.0",
-				"node-gyp": "3.6.2",
-				"npmlog": "4.1.2",
-				"request": "2.79.0",
-				"sass-graph": "2.2.4",
-				"stdout-stream": "1.4.0",
-				"true-case-path": "1.0.2"
-			},
-			"dependencies": {
-				"cross-spawn": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-					"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-					"dev": true,
-					"requires": {
-						"lru-cache": "4.1.2",
-						"which": "1.3.0"
-					}
-				},
-				"gaze": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-					"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-					"dev": true,
-					"requires": {
-						"globule": "1.2.0"
-					}
-				},
-				"globule": {
-					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-					"integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
-					"dev": true,
-					"requires": {
-						"glob": "7.1.2",
-						"lodash": "4.17.5",
-						"minimatch": "3.0.4"
-					}
-				},
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-					"dev": true
-				},
-				"lodash.assign": {
-					"version": "4.2.0",
-					"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-					"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-					"dev": true
-				}
-			}
-		},
-		"node-status-codes": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
-			"integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
-		},
-		"nopt": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"requires": {
-				"abbrev": "1.1.1"
-			}
-		},
-		"normalize-package-data": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-			"requires": {
-				"hosted-git-info": "2.6.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "4.3.6",
-				"validate-npm-package-license": "3.0.3"
-			}
-		},
-		"normalize-path": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"requires": {
-				"remove-trailing-separator": "1.1.0"
-			}
-		},
-		"normalize-url": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-			"integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-			"requires": {
-				"prepend-http": "2.0.0",
-				"query-string": "5.1.1",
-				"sort-keys": "2.0.0"
-			},
-			"dependencies": {
-				"prepend-http": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-				}
-			}
-		},
-		"npm-keyword": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-5.0.0.tgz",
-			"integrity": "sha1-mbha7Cn8s4jS3TUfABO/Umh4fmc=",
-			"requires": {
-				"got": "7.1.0",
-				"registry-url": "3.1.0"
-			},
-			"dependencies": {
-				"got": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
-					"integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
-					"requires": {
-						"decompress-response": "3.3.0",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"is-plain-obj": "1.1.0",
-						"is-retry-allowed": "1.1.0",
-						"is-stream": "1.1.0",
-						"isurl": "1.0.0",
-						"lowercase-keys": "1.0.0",
-						"p-cancelable": "0.3.0",
-						"p-timeout": "1.2.1",
-						"safe-buffer": "5.1.1",
-						"timed-out": "4.0.1",
-						"url-parse-lax": "1.0.0",
-						"url-to-options": "1.0.1"
-					}
-				},
-				"timed-out": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-				}
-			}
-		},
-		"npmlog": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"requires": {
-				"are-we-there-yet": "1.1.4",
-				"console-control-strings": "1.1.0",
-				"gauge": "2.7.4",
-				"set-blocking": "2.0.0"
-			}
-		},
-		"number-is-nan": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
-		},
-		"oauth-sign": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-			"integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-		},
-		"object-assign": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-			"integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
-		},
-		"object-component": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-			"integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-		},
-		"object-copy": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-			"requires": {
-				"copy-descriptor": "0.1.1",
-				"define-property": "0.2.5",
-				"kind-of": "3.2.2"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "0.1.6"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"object-path": {
-			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
-			"integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU="
-		},
-		"object-visit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-			"requires": {
-				"isobject": "3.0.1"
-			}
-		},
-		"object.defaults": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
-			"integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
-			"requires": {
-				"array-each": "1.0.1",
-				"array-slice": "1.1.0",
-				"for-own": "1.0.0",
-				"isobject": "3.0.1"
-			}
-		},
-		"object.map": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
-			"integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
-			"requires": {
-				"for-own": "1.0.0",
-				"make-iterator": "1.0.1"
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
-			},
-			"dependencies": {
-				"for-own": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-					"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-					"requires": {
-						"for-in": "1.0.2"
-					}
-				}
-			}
-		},
-		"object.pick": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-			"requires": {
-				"isobject": "3.0.1"
-			}
-		},
-		"on-finished": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"requires": {
-				"ee-first": "1.1.1"
-			}
-		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1.0.2"
-			}
-		},
-		"onetime": {
-			"version": "1.1.0",
-			"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-		},
-		"openurl": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
-			"integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
-		},
-		"opn": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-			"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-			"requires": {
-				"object-assign": "4.1.1",
-				"pinkie-promise": "2.0.1"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"optimist": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-			"requires": {
-				"minimist": "0.0.10",
-				"wordwrap": "0.0.3"
-			},
-			"dependencies": {
-				"minimist": {
-					"version": "0.0.10",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-				}
-			}
-		},
-		"orchestrator": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
-			"integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
-			"requires": {
-				"end-of-stream": "0.1.5",
-				"sequencify": "0.0.7",
-				"stream-consume": "0.1.1"
-			}
-		},
-		"ordered-read-streams": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
-			"integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
-		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-		},
-		"os-locale": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"requires": {
-				"lcid": "1.0.0"
-			}
-		},
-		"os-shim": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
-			"integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
-		},
-		"os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-		},
-		"osenv": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-			"requires": {
-				"os-homedir": "1.0.2",
-				"os-tmpdir": "1.0.2"
-			}
-		},
-		"p-cancelable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw=="
-		},
-		"p-finally": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-			"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-		},
-		"p-is-promise": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-			"integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
-		},
-		"p-timeout": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
-			"integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
-			"requires": {
-				"p-finally": "1.0.0"
-			}
-		},
-		"package-json": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
-			"integrity": "sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==",
-			"requires": {
-				"got": "8.3.2",
-				"registry-auth-token": "3.3.2",
-				"registry-url": "3.1.0",
-				"semver": "5.5.0"
-			},
-			"dependencies": {
-				"got": {
-					"version": "8.3.2",
-					"resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-					"integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
-					"requires": {
-						"@sindresorhus/is": "0.7.0",
-						"cacheable-request": "2.1.4",
-						"decompress-response": "3.3.0",
-						"duplexer3": "0.1.4",
-						"get-stream": "3.0.0",
-						"into-stream": "3.1.0",
-						"is-retry-allowed": "1.1.0",
-						"isurl": "1.0.0",
-						"lowercase-keys": "1.0.0",
-						"mimic-response": "1.0.0",
-						"p-cancelable": "0.4.1",
-						"p-timeout": "2.0.1",
-						"pify": "3.0.0",
-						"safe-buffer": "5.1.1",
-						"timed-out": "4.0.1",
-						"url-parse-lax": "3.0.0",
-						"url-to-options": "1.0.1"
-					}
-				},
-				"p-cancelable": {
-					"version": "0.4.1",
-					"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-					"integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
-				},
-				"p-timeout": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-					"integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-					"requires": {
-						"p-finally": "1.0.0"
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-				},
-				"prepend-http": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
-					"integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
-				},
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-				},
-				"timed-out": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-					"integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
-				},
-				"url-parse-lax": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
-					"integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
-					"requires": {
-						"prepend-http": "2.0.0"
-					}
-				}
-			}
-		},
-		"parse-filepath": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
-			"integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
-			"requires": {
-				"is-absolute": "1.0.0",
-				"map-cache": "0.2.2",
-				"path-root": "0.1.1"
-			}
-		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"requires": {
-						"is-extglob": "1.0.0"
-					}
-				}
-			}
-		},
-		"parse-json": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"requires": {
-				"error-ex": "1.3.1"
-			}
-		},
-		"parse-passwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-			"integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
-		},
-		"parseqs": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
-			"integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
-			"requires": {
-				"better-assert": "1.0.2"
-			}
-		},
-		"parseuri": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
-			"integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
-			"requires": {
-				"better-assert": "1.0.2"
-			}
-		},
-		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-		},
-		"pascalcase": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
-		},
-		"path-exists": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-			"requires": {
-				"pinkie-promise": "2.0.1"
-			}
-		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
-		"path-is-inside": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-			"integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
-		},
-		"path-parse": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-			"integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
-		},
-		"path-root": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-			"integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
-			"requires": {
-				"path-root-regex": "0.1.2"
-			}
-		},
-		"path-root-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-			"integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
-		},
-		"path-type": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
-			}
-		},
-		"pause-stream": {
-			"version": "0.0.11",
-			"resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
-			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-			"requires": {
-				"through": "2.3.8"
-			}
-		},
-		"pify": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-			"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-		},
-		"pinkie": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-		},
-		"pinkie-promise": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"requires": {
-				"pinkie": "2.0.4"
-			}
-		},
-		"plexer": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/plexer/-/plexer-0.0.3.tgz",
-			"integrity": "sha1-M00dfNYjJGVBfppmNkkB8pIw9TE=",
-			"requires": {
-				"readable-stream": "1.1.14"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
-			}
-		},
-		"plugin-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-			"integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
-			"requires": {
-				"ansi-colors": "1.1.0",
-				"arr-diff": "4.0.0",
-				"arr-union": "3.1.0",
-				"extend-shallow": "3.0.2"
-			}
-		},
-		"plur": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-			"integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
-			"requires": {
-				"irregular-plurals": "1.4.0"
-			}
-		},
-		"portfinder": {
-			"version": "1.0.13",
-			"resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
-			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
-			"requires": {
-				"async": "1.5.2",
-				"debug": "2.6.9",
-				"mkdirp": "0.5.1"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				}
-			}
-		},
-		"portscanner": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-			"integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
-			"requires": {
-				"async": "1.5.2",
-				"is-number-like": "1.0.8"
-			},
-			"dependencies": {
-				"async": {
-					"version": "1.5.2",
-					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-				}
-			}
-		},
-		"posix-character-classes": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
-		},
-		"prepend-http": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-		},
-		"pretty-hrtime": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-			"integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
-		},
-		"process-nextick-args": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-		},
-		"pseudomap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-		},
-		"punycode": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-			"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-		},
-		"qs": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz",
-			"integrity": "sha1-EIirr53MCuWuRbcJ5sa1iIsjkjw="
-		},
-		"query-string": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-			"integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-			"requires": {
-				"decode-uri-component": "0.2.0",
-				"object-assign": "4.1.1",
-				"strict-uri-encode": "1.1.0"
-			},
-			"dependencies": {
-				"object-assign": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-				}
-			}
-		},
-		"randomatic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
-			"requires": {
-				"is-number": "4.0.0",
-				"kind-of": "6.0.2",
-				"math-random": "1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-				}
-			}
-		},
-		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-		},
-		"raw-body": {
-			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-			"integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
-			"requires": {
-				"bytes": "2.4.0",
-				"iconv-lite": "0.4.13",
-				"unpipe": "1.0.0"
-			},
-			"dependencies": {
-				"bytes": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-					"integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
-				}
-			}
-		},
-		"rc": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.6.tgz",
-			"integrity": "sha1-6xiYnG1PTxYsOZ953dKfODVWgJI=",
-			"requires": {
-				"deep-extend": "0.4.2",
-				"ini": "1.3.5",
-				"minimist": "1.2.0",
-				"strip-json-comments": "2.0.1"
-			}
-		},
-		"read-all-stream": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
-			"integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-			"requires": {
-				"pinkie-promise": "2.0.1",
-				"readable-stream": "2.3.5"
-			}
-		},
-		"read-pkg": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
-			}
-		},
-		"read-pkg-up": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
-			}
-		},
-		"readable-stream": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
-			"integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
-			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "2.0.0",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
-			}
-		},
-		"readdirp": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"minimatch": "3.0.4",
-				"readable-stream": "2.3.5",
-				"set-immediate-shim": "1.0.1"
-			}
-		},
-		"readline2": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"mute-stream": "0.0.5"
-			},
-			"dependencies": {
-				"mute-stream": {
-					"version": "0.0.5",
-					"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-					"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
-				}
-			}
-		},
-		"rechoir": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-			"integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-			"requires": {
-				"resolve": "1.6.0"
-			}
-		},
-		"redent": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
-			}
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"requires": {
-				"is-equal-shallow": "0.1.3"
-			}
-		},
-		"regex-not": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"requires": {
-				"extend-shallow": "3.0.2",
-				"safe-regex": "1.1.0"
-			}
-		},
-		"registry-auth-token": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-			"integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-			"requires": {
-				"rc": "1.2.6",
-				"safe-buffer": "5.1.1"
-			}
-		},
-		"registry-url": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-			"integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-			"requires": {
-				"rc": "1.2.6"
-			}
-		},
-		"remove-trailing-separator": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
-		},
-		"repeat-element": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
-		},
-		"repeat-string": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
-		},
-		"repeating": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"requires": {
-				"is-finite": "1.0.2"
-			}
-		},
-		"replace-ext": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-			"integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
-		},
-		"request": {
-			"version": "2.79.0",
-			"resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-			"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-			"requires": {
-				"aws-sign2": "0.6.0",
-				"aws4": "1.6.0",
-				"caseless": "0.11.0",
-				"combined-stream": "1.0.6",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.1.4",
-				"har-validator": "2.0.6",
-				"hawk": "3.1.3",
-				"http-signature": "1.1.1",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.18",
-				"oauth-sign": "0.8.2",
-				"qs": "6.3.2",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.4",
-				"tunnel-agent": "0.4.3",
-				"uuid": "3.2.1"
-			},
-			"dependencies": {
-				"qs": {
-					"version": "6.3.2",
-					"resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-					"integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw="
-				}
-			}
-		},
-		"require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
-		},
-		"require-main-filename": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-			"integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-		},
-		"requires-port": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
-		},
-		"resolve": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
-			"integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
-			"requires": {
-				"path-parse": "1.0.5"
-			}
-		},
-		"resolve-dir": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
-			"integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-			"requires": {
-				"expand-tilde": "2.0.2",
-				"global-modules": "1.0.0"
-			}
-		},
-		"resolve-url": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
-		},
-		"resp-modifier": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
-			"integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
-			"requires": {
-				"debug": "2.6.9",
-				"minimatch": "3.0.4"
-			}
-		},
-		"responselike": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-			"integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
-			"requires": {
-				"lowercase-keys": "1.0.0"
-			}
-		},
-		"restore-cursor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-			"requires": {
-				"exit-hook": "1.1.1",
-				"onetime": "1.1.0"
-			}
-		},
-		"ret": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-		},
-		"rimraf": {
-			"version": "2.6.2",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-			"requires": {
-				"glob": "7.1.2"
-			}
-		},
-		"roolz": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/roolz/-/roolz-1.0.2.tgz",
-			"integrity": "sha1-9GScCTA2bsSxs12cbFr9ofHpGM8=",
-			"requires": {
-				"drip": "1.4.0",
-				"lodash": "3.10.1",
-				"string-sub": "0.0.1"
-			}
-		},
-		"run-async": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-			"requires": {
-				"once": "1.4.0"
-			}
-		},
-		"run-sequence": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
-			"integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
-			"requires": {
-				"chalk": "1.1.3",
-				"gulp-util": "3.0.8"
-			}
-		},
-		"rx": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-			"integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-		},
-		"rx-lite": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
-		},
-		"safe-buffer": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-		},
-		"safe-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-			"requires": {
-				"ret": "0.1.15"
-			}
-		},
-		"safer-buffer": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-		},
-		"sass-graph": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-			"integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
-			"requires": {
-				"glob": "7.1.2",
-				"lodash": "4.17.5",
-				"scss-tokenizer": "0.2.3",
-				"yargs": "7.1.0"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.5",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-					"integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-				}
-			}
-		},
-		"sax": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-		},
-		"scss-tokenizer": {
-			"version": "0.2.3",
-			"resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-			"integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
-			"requires": {
-				"js-base64": "2.4.3",
-				"source-map": "0.4.4"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.4.4",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-					"requires": {
-						"amdefine": "1.0.1"
-					}
-				}
-			}
-		},
-		"semver": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
-			"integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
-		},
-		"semver-diff": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-			"integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-			"requires": {
-				"semver": "5.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-					"integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
-				}
-			}
-		},
-		"send": {
-			"version": "0.16.2",
-			"resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-			"integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-			"requires": {
-				"debug": "2.6.9",
-				"depd": "1.1.2",
-				"destroy": "1.0.4",
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"etag": "1.8.1",
-				"fresh": "0.5.2",
-				"http-errors": "1.6.3",
-				"mime": "1.4.1",
-				"ms": "2.0.0",
-				"on-finished": "2.3.0",
-				"range-parser": "1.2.0",
-				"statuses": "1.4.0"
-			},
-			"dependencies": {
-				"http-errors": {
-					"version": "1.6.3",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-					"requires": {
-						"depd": "1.1.2",
-						"inherits": "2.0.3",
-						"setprototypeof": "1.1.0",
-						"statuses": "1.4.0"
-					}
-				}
-			}
-		},
-		"sequencify": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
-			"integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
-		},
-		"serve-index": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
-			"integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
-			"requires": {
-				"accepts": "1.3.5",
-				"batch": "0.5.3",
-				"debug": "2.2.0",
-				"escape-html": "1.0.3",
-				"http-errors": "1.5.1",
-				"mime-types": "2.1.18",
-				"parseurl": "1.3.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"requires": {
-						"ms": "0.7.1"
-					}
-				},
-				"http-errors": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
-					"integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-					"requires": {
-						"inherits": "2.0.3",
-						"setprototypeof": "1.0.2",
-						"statuses": "1.4.0"
-					}
-				},
-				"ms": {
-					"version": "0.7.1",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-					"integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
-				},
-				"setprototypeof": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
-					"integrity": "sha1-gaVSFB7BBLiOic44MQOtXGZWTQg="
-				}
-			}
-		},
-		"serve-static": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-			"integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-			"requires": {
-				"encodeurl": "1.0.2",
-				"escape-html": "1.0.3",
-				"parseurl": "1.3.2",
-				"send": "0.16.2"
-			}
-		},
-		"server-destroy": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
-			"integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
-		},
-		"set-blocking": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
-		},
-		"set-immediate-shim": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-			"integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
-		},
-		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-			"requires": {
-				"extend-shallow": "2.0.1",
-				"is-extendable": "0.1.1",
-				"is-plain-object": "2.0.4",
-				"split-string": "3.1.0"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "0.1.1"
-					}
-				}
-			}
-		},
-		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-		},
-		"shebang-command": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-			"requires": {
-				"shebang-regex": "1.0.0"
-			}
-		},
-		"shebang-regex": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
-		},
-		"sigmund": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-		},
-		"signal-exit": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-		},
-		"slide": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
-		},
-		"snapdragon": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"requires": {
-				"base": "0.11.2",
-				"debug": "2.6.9",
-				"define-property": "0.2.5",
-				"extend-shallow": "2.0.1",
-				"map-cache": "0.2.2",
-				"source-map": "0.5.7",
-				"source-map-resolve": "0.5.2",
-				"use": "3.1.0"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "0.1.6"
-					}
-				},
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "0.1.1"
-					}
-				},
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
-		},
-		"snapdragon-node": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"requires": {
-				"define-property": "1.0.0",
-				"isobject": "3.0.1",
-				"snapdragon-util": "3.0.1"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-					"requires": {
-						"is-descriptor": "1.0.2"
-					}
-				},
-				"is-accessor-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-data-descriptor": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-					"requires": {
-						"kind-of": "6.0.2"
-					}
-				},
-				"is-descriptor": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-					"requires": {
-						"is-accessor-descriptor": "1.0.0",
-						"is-data-descriptor": "1.0.0",
-						"kind-of": "6.0.2"
-					}
-				}
-			}
-		},
-		"snapdragon-util": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"requires": {
-				"kind-of": "3.2.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"sntp": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"requires": {
-				"hoek": "2.16.3"
-			}
-		},
-		"socket.io": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.0.4.tgz",
-			"integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
-			"requires": {
-				"debug": "2.6.9",
-				"engine.io": "3.1.5",
-				"socket.io-adapter": "1.1.1",
-				"socket.io-client": "2.0.4",
-				"socket.io-parser": "3.1.3"
-			}
-		},
-		"socket.io-adapter": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
-			"integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
-		},
-		"socket.io-client": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-			"integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
-			"requires": {
-				"backo2": "1.0.2",
-				"base64-arraybuffer": "0.1.5",
-				"component-bind": "1.0.0",
-				"component-emitter": "1.2.1",
-				"debug": "2.6.9",
-				"engine.io-client": "3.1.6",
-				"has-cors": "1.1.0",
-				"indexof": "0.0.1",
-				"object-component": "0.0.3",
-				"parseqs": "0.0.5",
-				"parseuri": "0.0.5",
-				"socket.io-parser": "3.1.3",
-				"to-array": "0.1.4"
-			}
-		},
-		"socket.io-parser": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
-			"integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
-			"requires": {
-				"component-emitter": "1.2.1",
-				"debug": "3.1.0",
-				"has-binary2": "1.0.3",
-				"isarray": "2.0.1"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"isarray": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-					"integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-				}
-			}
-		},
-		"sort-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-			"integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-			"requires": {
-				"is-plain-obj": "1.1.0"
-			}
-		},
-		"source-map": {
-			"version": "0.1.43",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-			"integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-			"requires": {
-				"amdefine": "1.0.1"
-			}
-		},
-		"source-map-resolve": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
-			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
-			"requires": {
-				"atob": "2.1.1",
-				"decode-uri-component": "0.2.0",
-				"resolve-url": "0.2.1",
-				"source-map-url": "0.4.0",
-				"urix": "0.1.0"
-			}
-		},
-		"source-map-url": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
-		},
-		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
-		},
-		"spawn-sync": {
-			"version": "1.0.15",
-			"resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
-			"integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-			"requires": {
-				"concat-stream": "1.6.2",
-				"os-shim": "0.1.3"
-			}
-		},
-		"spdx-correct": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
-			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
-			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.0"
-			}
-		},
-		"spdx-exceptions": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-			"integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
-		},
-		"spdx-expression-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
-			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.0"
-			}
-		},
-		"spdx-license-ids": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
-		},
-		"split": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-			"requires": {
-				"through": "2.3.8"
-			}
-		},
-		"split-string": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"requires": {
-				"extend-shallow": "3.0.2"
-			}
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-			"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-		},
-		"sshpk": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
-			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
-		},
-		"static-extend": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-			"requires": {
-				"define-property": "0.2.5",
-				"object-copy": "0.1.0"
-			},
-			"dependencies": {
-				"define-property": {
-					"version": "0.2.5",
-					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-					"requires": {
-						"is-descriptor": "0.1.6"
-					}
-				}
-			}
-		},
-		"statuses": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-			"integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-		},
-		"stdout-stream": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
-			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
-			"requires": {
-				"readable-stream": "2.3.5"
-			}
-		},
-		"stream-combiner": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-			"requires": {
-				"duplexer": "0.1.1"
-			}
-		},
-		"stream-consume": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
-			"integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
-		},
-		"stream-shift": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-			"integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
-		},
-		"stream-throttle": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
-			"integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
-			"requires": {
-				"commander": "2.15.1",
-				"limiter": "1.1.3"
-			}
-		},
-		"streamqueue": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.0.6.tgz",
-			"integrity": "sha1-ZvX17JTpuK8knkrsLdH3Qb/pTeM=",
-			"requires": {
-				"readable-stream": "1.1.14"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				}
-			}
-		},
-		"strict-uri-encode": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-			"integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
-		},
-		"string-sub": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/string-sub/-/string-sub-0.0.1.tgz",
-			"integrity": "sha1-Z8lZrDoU5c/igP7wi0IcJAUOqk0="
-		},
-		"string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
-			}
-		},
-		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-			"requires": {
-				"safe-buffer": "5.1.1"
-			}
-		},
-		"stringify-object": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
-			"integrity": "sha1-xi0RAj6yH+LZsIe+A5om3zsioJ0=",
-			"requires": {
-				"is-plain-obj": "1.1.0",
-				"is-regexp": "1.0.0"
-			}
-		},
-		"stringstream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-			"integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
-		},
-		"strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"requires": {
-				"ansi-regex": "2.1.1"
-			}
-		},
-		"strip-bom": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
-			"integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
-			"requires": {
-				"first-chunk-stream": "1.0.0",
-				"is-utf8": "0.2.1"
-			}
-		},
-		"strip-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"requires": {
-				"get-stdin": "4.0.1"
-			}
-		},
-		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-		},
-		"supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
-		},
-		"tar": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-			"requires": {
-				"block-stream": "0.0.9",
-				"fstream": "1.0.11",
-				"inherits": "2.0.3"
-			}
-		},
-		"tea-concat": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/tea-concat/-/tea-concat-0.1.0.tgz",
-			"integrity": "sha1-6i6QdAD914pjNM4CD6PGlQLZnoQ="
-		},
-		"ternary-stream": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
-			"integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
-			"requires": {
-				"duplexify": "3.5.4",
-				"fork-stream": "0.0.4",
-				"merge-stream": "1.0.1",
-				"through2": "2.0.3"
-			},
-			"dependencies": {
-				"merge-stream": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-					"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-					"requires": {
-						"readable-stream": "2.3.5"
-					}
-				}
-			}
-		},
-		"tfunk": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
-			"integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
-			"requires": {
-				"chalk": "1.1.3",
-				"object-path": "0.9.2"
-			}
-		},
-		"through": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-		},
-		"through2": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-			"requires": {
-				"readable-stream": "2.3.5",
-				"xtend": "4.0.1"
-			}
-		},
-		"tildify": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
-			"integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
-			"requires": {
-				"os-homedir": "1.0.2"
-			}
-		},
-		"time-stamp": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
-		},
-		"timed-out": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
-			"integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
-		},
-		"to-array": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-			"integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
-		},
-		"to-int": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/to-int/-/to-int-0.1.0.tgz",
-			"integrity": "sha1-OuACfPEcfyI3+DADtj77dkMVYW0="
-		},
-		"to-object-path": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-			"requires": {
-				"kind-of": "3.2.2"
-			},
-			"dependencies": {
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"requires": {
-						"is-buffer": "1.1.6"
-					}
-				}
-			}
-		},
-		"to-regex": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"requires": {
-				"define-property": "2.0.2",
-				"extend-shallow": "3.0.2",
-				"regex-not": "1.0.2",
-				"safe-regex": "1.1.0"
-			}
-		},
-		"to-regex-range": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-			"requires": {
-				"is-number": "3.0.0",
-				"repeat-string": "1.6.1"
-			}
-		},
-		"tough-cookie": {
-			"version": "2.3.4",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-			"requires": {
-				"punycode": "1.4.1"
-			}
-		},
-		"trim-newlines": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-			"integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
-		},
-		"true-case-path": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
-			"integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
-			"requires": {
-				"glob": "6.0.4"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "6.0.4",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				}
-			}
-		},
-		"tunnel-agent": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-			"integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
-		},
-		"tweetnacl": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"optional": true
-		},
-		"type-is": {
-			"version": "1.6.16",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-			"integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-			"requires": {
-				"media-typer": "0.3.0",
-				"mime-types": "2.1.18"
-			}
-		},
-		"typedarray": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-		},
-		"ua-parser-js": {
-			"version": "0.7.17",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
-			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
-		},
-		"uglify-js": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-			"integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-			"optional": true,
-			"requires": {
-				"async": "0.2.10",
-				"optimist": "0.3.7",
-				"source-map": "0.1.43"
-			},
-			"dependencies": {
-				"async": {
-					"version": "0.2.10",
-					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-					"optional": true
-				},
-				"optimist": {
-					"version": "0.3.7",
-					"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-					"integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-					"optional": true,
-					"requires": {
-						"wordwrap": "0.0.3"
-					}
-				}
-			}
-		},
-		"ultron": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-			"integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-		},
-		"unc-path-regex": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-			"integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
-		},
-		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-			"requires": {
-				"arr-union": "3.1.0",
-				"get-value": "2.0.6",
-				"is-extendable": "0.1.1",
-				"set-value": "0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"requires": {
-						"is-extendable": "0.1.1"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"requires": {
-						"extend-shallow": "2.0.1",
-						"is-extendable": "0.1.1",
-						"is-plain-object": "2.0.4",
-						"to-object-path": "0.3.0"
-					}
-				}
-			}
-		},
-		"unique-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
-			"integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
-		},
-		"universalify": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-			"integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
-		},
-		"unpipe": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-		},
-		"unset-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-			"requires": {
-				"has-value": "0.3.1",
-				"isobject": "3.0.1"
-			},
-			"dependencies": {
-				"has-value": {
-					"version": "0.3.1",
-					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-					"requires": {
-						"get-value": "2.0.6",
-						"has-values": "0.1.4",
-						"isobject": "2.1.0"
-					},
-					"dependencies": {
-						"isobject": {
-							"version": "2.1.0",
-							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-							"requires": {
-								"isarray": "1.0.0"
-							}
-						}
-					}
-				},
-				"has-values": {
-					"version": "0.1.4",
-					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
-				}
-			}
-		},
-		"unzip-response": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
-			"integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
-		},
-		"update-notifier": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
-			"integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-			"requires": {
-				"boxen": "0.6.0",
-				"chalk": "1.1.3",
-				"configstore": "2.1.0",
-				"is-npm": "1.0.0",
-				"latest-version": "2.0.0",
-				"lazy-req": "1.1.0",
-				"semver-diff": "2.1.0",
-				"xdg-basedir": "2.0.0"
-			}
-		},
-		"urix": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
-		},
-		"url-parse-lax": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-			"integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-			"requires": {
-				"prepend-http": "1.0.4"
-			}
-		},
-		"url-to-options": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-			"integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
-		},
-		"use": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
-			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-			"requires": {
-				"kind-of": "6.0.2"
-			}
-		},
-		"user-home": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
-			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-		},
-		"utils-merge": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-			"integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
-		},
-		"uuid": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-			"integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-		},
-		"uws": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/uws/-/uws-9.14.0.tgz",
-			"integrity": "sha512-HNMztPP5A1sKuVFmdZ6BPVpBQd5bUjNC8EFMFiICK+oho/OQsAJy5hnIx4btMHiOk8j04f/DbIlqnEZ9d72dqg==",
-			"optional": true
-		},
-		"v8flags": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
-			"integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-			"requires": {
-				"user-home": "1.1.1"
-			}
-		},
-		"validate-npm-package-license": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
-			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
-			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
-			}
-		},
-		"verror": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
-				"assert-plus": "1.0.0",
-				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
-			},
-			"dependencies": {
-				"assert-plus": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-					"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-				}
-			}
-		},
-		"vinyl": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-			"requires": {
-				"clone": "1.0.3",
-				"clone-stats": "0.0.1",
-				"replace-ext": "0.0.1"
-			}
-		},
-		"vinyl-fs": {
-			"version": "0.3.14",
-			"resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
-			"integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
-			"requires": {
-				"defaults": "1.0.3",
-				"glob-stream": "3.1.18",
-				"glob-watcher": "0.0.6",
-				"graceful-fs": "3.0.11",
-				"mkdirp": "0.5.1",
-				"strip-bom": "1.0.0",
-				"through2": "0.6.5",
-				"vinyl": "0.4.6"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
-					"integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
-				},
-				"graceful-fs": {
-					"version": "3.0.11",
-					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
-					"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-					"requires": {
-						"natives": "1.1.4"
-					}
-				},
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
-					}
-				},
-				"vinyl": {
-					"version": "0.4.6",
-					"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
-					"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
-					"requires": {
-						"clone": "0.2.0",
-						"clone-stats": "0.0.1"
-					}
-				}
-			}
-		},
-		"vinyl-paths": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/vinyl-paths/-/vinyl-paths-1.0.0.tgz",
-			"integrity": "sha1-/Ccq2pFbTD6CZM+wbeddPOB8ip4=",
-			"requires": {
-				"through2": "0.6.5"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "0.0.1",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-				},
-				"readable-stream": {
-					"version": "1.0.34",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-				},
-				"through2": {
-					"version": "0.6.5",
-					"resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-					"requires": {
-						"readable-stream": "1.0.34",
-						"xtend": "4.0.1"
-					}
-				}
-			}
-		},
-		"vinyl-sourcemaps-apply": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
-			"integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
-			"requires": {
-				"source-map": "0.5.7"
-			},
-			"dependencies": {
-				"source-map": {
-					"version": "0.5.7",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-				}
-			}
-		},
-		"websocket-driver": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-			"integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-			"requires": {
-				"http-parser-js": "0.4.11",
-				"websocket-extensions": "0.1.3"
-			}
-		},
-		"websocket-extensions": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-			"integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
-		},
-		"which": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-			"requires": {
-				"isexe": "2.0.0"
-			}
-		},
-		"which-module": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
-			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
-		},
-		"wide-align": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-			"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-			"requires": {
-				"string-width": "1.0.2"
-			}
-		},
-		"widest-line": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-			"integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-			"requires": {
-				"string-width": "1.0.2"
-			}
-		},
-		"window-size": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
-			"integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
-		},
-		"wordwrap": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-		},
-		"wrap-ansi": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
-			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-		},
-		"write-file-atomic": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"slide": "1.1.6"
-			}
-		},
-		"ws": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-			"requires": {
-				"async-limiter": "1.0.0",
-				"safe-buffer": "5.1.1",
-				"ultron": "1.1.1"
-			}
-		},
-		"xdg-basedir": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-			"integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-			"requires": {
-				"os-homedir": "1.0.2"
-			}
-		},
-		"xml2js": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-			"requires": {
-				"sax": "1.2.4",
-				"xmlbuilder": "9.0.7"
-			}
-		},
-		"xmlbuilder": {
-			"version": "9.0.7",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-		},
-		"xmlhttprequest-ssl": {
-			"version": "1.5.5",
-			"resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-			"integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
-		},
-		"xtend": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-		},
-		"y18n": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
-		},
-		"yallist": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-			"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-		},
-		"yargs": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-			"integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
-			"requires": {
-				"camelcase": "3.0.0",
-				"cliui": "3.2.0",
-				"decamelize": "1.2.0",
-				"get-caller-file": "1.0.2",
-				"os-locale": "1.4.0",
-				"read-pkg-up": "1.0.1",
-				"require-directory": "2.1.1",
-				"require-main-filename": "1.0.1",
-				"set-blocking": "2.0.0",
-				"string-width": "1.0.2",
-				"which-module": "1.0.0",
-				"y18n": "3.2.1",
-				"yargs-parser": "5.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				}
-			}
-		},
-		"yargs-parser": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
-			"integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
-			"requires": {
-				"camelcase": "3.0.0"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
-					"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-				}
-			}
-		},
-		"yazl": {
-			"version": "2.4.3",
-			"resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
-			"integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
-			"requires": {
-				"buffer-crc32": "0.2.13"
-			}
-		},
-		"yeast": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-		}
-	}
+  "name": "liferay-theme-tasks",
+  "version": "8.0.0-beta.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "after": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-align": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+    },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+    },
+    "anymatch": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+      "requires": {
+        "micromatch": "2.3.11",
+        "normalize-path": "2.1.1"
+      }
+    },
+    "applause": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/applause/-/applause-0.4.3.tgz",
+      "integrity": "sha1-Zmy9fw+c5U3L3mcM7qguYTORvb0=",
+      "requires": {
+        "cson-parser": "1.3.5",
+        "js-yaml": "3.12.0",
+        "lodash": "3.10.1"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+      "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+      "requires": {
+        "arr-flatten": "1.1.0"
+      }
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+    },
+    "array-differ": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
+    },
+    "array-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+      "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8="
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+    },
+    "array-slice": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+      "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w=="
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+      "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "arraybuffer.slice": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+    },
+    "async-each-series": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+      "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+      "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+    },
+    "aws4": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "requires": {
+        "follow-redirects": "1.5.1",
+        "is-buffer": "1.1.6"
+      }
+    },
+    "backo2": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "requires": {
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.2.1",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.1",
+        "pascalcase": "0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "base64-arraybuffer": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+    },
+    "base64id": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+      "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+    },
+    "batch": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+      "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "beeper": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+    },
+    "better-assert": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+      "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "requires": {
+        "callsite": "1.0.0"
+      }
+    },
+    "binary-extensions": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
+      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+    },
+    "blob": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "body-parser": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
+      "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
+      "requires": {
+        "bytes": "2.2.0",
+        "content-type": "1.0.4",
+        "debug": "2.2.0",
+        "depd": "1.1.2",
+        "http-errors": "1.3.1",
+        "iconv-lite": "0.4.13",
+        "on-finished": "2.3.0",
+        "qs": "5.2.0",
+        "raw-body": "2.1.7",
+        "type-is": "1.6.16"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+          "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg="
+        },
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "http-errors": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
+          "requires": {
+            "inherits": "2.0.3",
+            "statuses": "1.3.1"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        },
+        "qs": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
+          "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4="
+        },
+        "raw-body": {
+          "version": "2.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
+          "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
+          "requires": {
+            "bytes": "2.4.0",
+            "iconv-lite": "0.4.13",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+              "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+            }
+          }
+        }
+      }
+    },
+    "boom": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "bourbon": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/bourbon/-/bourbon-4.2.3.tgz",
+      "integrity": "sha1-1gYckMDihzfBoNAVZy1yvpdw//A="
+    },
+    "boxen": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "requires": {
+        "ansi-align": "1.1.0",
+        "camelcase": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "filled-array": "1.1.0",
+        "object-assign": "4.1.1",
+        "repeating": "2.0.1",
+        "string-width": "1.0.2",
+        "widest-line": "1.0.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+      "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+      "requires": {
+        "expand-range": "1.8.2",
+        "preserve": "0.2.0",
+        "repeat-element": "1.1.2"
+      }
+    },
+    "browser-sync": {
+      "version": "2.24.5",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.5.tgz",
+      "integrity": "sha512-r6ZRYncfYRGerw4Rh5S8Q9x9WKDdrwH572hd3ofsYgn0Px6a6EqXiLBVTCss2+2a45G9ZgjRHSeo9YY56UpgKw==",
+      "requires": {
+        "browser-sync-ui": "1.0.1",
+        "bs-recipes": "1.3.4",
+        "chokidar": "1.7.0",
+        "connect": "3.6.6",
+        "connect-history-api-fallback": "1.5.0",
+        "dev-ip": "1.0.1",
+        "easy-extender": "2.3.2",
+        "eazy-logger": "3.0.2",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "fs-extra": "3.0.1",
+        "http-proxy": "1.15.2",
+        "immutable": "3.8.2",
+        "localtunnel": "1.9.0",
+        "micromatch": "2.3.11",
+        "opn": "4.0.2",
+        "portscanner": "2.1.1",
+        "qs": "6.2.3",
+        "raw-body": "2.3.3",
+        "resp-modifier": "6.0.2",
+        "rx": "4.1.0",
+        "serve-index": "1.9.1",
+        "serve-static": "1.13.2",
+        "server-destroy": "1.0.1",
+        "socket.io": "2.1.1",
+        "ua-parser-js": "0.7.17",
+        "yargs": "6.4.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "3.0.1",
+            "universalify": "0.1.2"
+          }
+        }
+      }
+    },
+    "browser-sync-ui": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
+      "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
+      "requires": {
+        "async-each-series": "0.1.1",
+        "connect-history-api-fallback": "1.5.0",
+        "immutable": "3.8.2",
+        "server-destroy": "1.0.1",
+        "socket.io-client": "2.0.4",
+        "stream-throttle": "0.1.3"
+      }
+    },
+    "bs-recipes": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+      "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "requires": {
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.2.1",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.0",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.0",
+        "unset-value": "1.0.0"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY="
+        }
+      }
+    },
+    "callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
+    "camelcase": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+      "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "requires": {
+        "camelcase": "2.1.1",
+        "map-obj": "1.0.1"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        }
+      }
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+      "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+      "requires": {
+        "anymatch": "1.3.2",
+        "async-each": "1.0.1",
+        "fsevents": "1.2.4",
+        "glob-parent": "2.0.0",
+        "inherits": "2.0.3",
+        "is-binary-path": "1.0.1",
+        "is-glob": "2.0.1",
+        "path-is-absolute": "1.0.1",
+        "readdirp": "2.1.0"
+      }
+    },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "requires": {
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "clay": {
+      "version": "2.0.0-rc.9",
+      "resolved": "https://registry.npmjs.org/clay/-/clay-2.0.0-rc.9.tgz",
+      "integrity": "sha512-EW1NFhUwOetG9HbaZYoqZlK2eYrfZHVnK36IrlkSpNnrLbPfJzU0eHbVYFfYsNKcb5rH5x9McRKtJgRzGhC8ww=="
+    },
+    "cli": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.5.tgz",
+      "integrity": "sha1-ePlIXNFhtWbppsctcXDEJw6B22E=",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+    },
+    "cli-color": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.2.3.tgz",
+      "integrity": "sha1-CiXOrlpqFgK+f3fShWPDZwAnTog=",
+      "requires": {
+        "es5-ext": "0.9.2",
+        "memoizee": "0.2.6"
+      }
+    },
+    "cli-color-keywords": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/cli-color-keywords/-/cli-color-keywords-0.0.1.tgz",
+      "integrity": "sha1-3eoJX653nJ5LT0FYHsenbbSOlLc=",
+      "requires": {
+        "chalk": "1.1.3",
+        "lodash": "3.10.1"
+      }
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wrap-ansi": "2.1.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
+    "clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
+    },
+    "clone-stats": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+      "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA="
+    },
+    "cloneable-readable": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.2.tgz",
+      "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
+      "requires": {
+        "inherits": "2.0.3",
+        "process-nextick-args": "2.0.0",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "requires": {
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
+      }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew=="
+    },
+    "compass-mixins": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/compass-mixins/-/compass-mixins-0.12.10.tgz",
+      "integrity": "sha1-zZ8V+CnE6WDMQ7sibwSbKL65nUE="
+    },
+    "component-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "component-inherit": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "requires": {
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "configstore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "requires": {
+        "dot-prop": "3.0.0",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "os-tmpdir": "1.0.2",
+        "osenv": "0.1.5",
+        "uuid": "2.0.3",
+        "write-file-atomic": "1.3.4",
+        "xdg-basedir": "2.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+        }
+      }
+    },
+    "connect": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+      "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.1.0",
+        "parseurl": "1.3.2",
+        "utils-merge": "1.0.1"
+      }
+    },
+    "connect-history-api-fallback": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+      "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "content-formatter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-formatter/-/content-formatter-1.1.0.tgz",
+      "integrity": "sha1-N4/I4IDGF/pAvN/GwdiMNJ40wfo=",
+      "requires": {
+        "drip": "1.4.0",
+        "lodash": "3.10.1",
+        "string-sub": "0.0.1"
+      }
+    },
+    "content-logger": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/content-logger/-/content-logger-0.0.3.tgz",
+      "integrity": "sha1-6s1fuI8e4tT5BFNYfqaOIaf0n9I=",
+      "requires": {
+        "content-logger-handlebars-helpers": "0.0.1",
+        "drip": "1.4.0",
+        "lodash": "3.10.1"
+      }
+    },
+    "content-logger-handlebars-helpers": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/content-logger-handlebars-helpers/-/content-logger-handlebars-helpers-0.0.1.tgz",
+      "integrity": "sha1-V797IGgUio4PZItp+SnF0qUNQr0=",
+      "requires": {
+        "cli-color-keywords": "0.0.1",
+        "handlebars": "3.0.3",
+        "lodash": "3.10.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "convert-bootstrap-2-to-3": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/convert-bootstrap-2-to-3/-/convert-bootstrap-2-to-3-1.0.4.tgz",
+      "integrity": "sha512-hs6uQNMSyeRao5G3z4gu+lYVLXC2zt8FDSN2VilUq+lWQLJKgIRDrHufhjQ7Xpy8ZsWQ3CSOBJG93so7BXOYDQ==",
+      "requires": {
+        "async": "0.7.0",
+        "cli": "0.4.5",
+        "cli-color-keywords": "0.0.1",
+        "content-formatter": "1.1.0",
+        "content-logger": "0.0.3",
+        "diff": "1.4.0",
+        "lodash": "3.10.1",
+        "optimist": "0.6.1",
+        "roolz": "1.0.2",
+        "string-sub": "0.0.1",
+        "to-int": "0.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.7.0.tgz",
+          "integrity": "sha1-RCng5i9d4KVPN0WMSfC4l+tSraU="
+        }
+      }
+    },
+    "convert-source-map": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-2.2.3.tgz",
+      "integrity": "sha1-+sViAt/T0N2GF3jy2iA79DS7ghw=",
+      "requires": {
+        "cross-spawn-async": "2.2.5",
+        "spawn-sync": "1.0.15"
+      }
+    },
+    "cross-spawn-async": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
+      "requires": {
+        "lru-cache": "4.1.3",
+        "which": "1.3.1"
+      }
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+      "requires": {
+        "boom": "2.10.1"
+      }
+    },
+    "cson-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+      "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
+      "requires": {
+        "coffee-script": "1.12.7"
+      }
+    },
+    "css-stringify": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.4.1.tgz",
+      "integrity": "sha1-JSzL8D9yOgCb3Ydw/n6ydBca/fo=",
+      "requires": {
+        "source-map": "0.1.43"
+      }
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "requires": {
+        "array-find-index": "1.0.2"
+      }
+    },
+    "dargs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-2.1.0.tgz",
+      "integrity": "sha1-RsJ/+rH/sTeO8hJZchNxn+YCvJM="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "dateformat": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+      "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "requires": {
+        "clone": "1.0.4"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        }
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "requires": {
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "del": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-1.2.1.tgz",
+      "integrity": "sha1-rtblvNfLcyXfNPVjEl+iZbLBoBQ=",
+      "requires": {
+        "each-async": "1.1.1",
+        "globby": "2.1.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "3.0.0",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "globby": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-2.1.0.tgz",
+          "integrity": "sha1-npGSvNM/Srak+JTl5+qLcTITxII=",
+          "requires": {
+            "array-union": "1.0.2",
+            "async": "1.5.2",
+            "glob": "5.0.15",
+            "object-assign": "3.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecated": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz",
+      "integrity": "sha1-+cmvVGSvoeepcUWKi97yqpTVuxk="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+    },
+    "dev-ip": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+      "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8="
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
+    "drip": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/drip/-/drip-1.4.0.tgz",
+      "integrity": "sha1-JDhhZq2QrsZ9aYYaGAieET7fJgI=",
+      "requires": {
+        "tea-concat": "0.1.0"
+      }
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+    },
+    "duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
+      }
+    },
+    "each-async": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+      "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
+      "requires": {
+        "onetime": "1.1.0",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "easy-extender": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.2.tgz",
+      "integrity": "sha1-PTJI/r4rFZYHMW2PnPSRwWZIIh0=",
+      "requires": {
+        "lodash": "3.10.1"
+      }
+    },
+    "eazy-logger": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+      "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
+      "requires": {
+        "tfunk": "3.1.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "engine.io": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+      "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+      "requires": {
+        "accepts": "1.3.5",
+        "base64id": "1.0.0",
+        "cookie": "0.3.1",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "ws": "3.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-client": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
+      "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "component-inherit": "0.0.3",
+        "debug": "3.1.0",
+        "engine.io-parser": "2.1.2",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "ws": "3.3.3",
+        "xmlhttprequest-ssl": "1.5.5",
+        "yeast": "0.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+      "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+      "requires": {
+        "after": "0.8.2",
+        "arraybuffer.slice": "0.0.7",
+        "base64-arraybuffer": "0.1.5",
+        "blob": "0.0.4",
+        "has-binary2": "1.0.3"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.9.2.tgz",
+      "integrity": "sha1-0uMJ0fIjsHGGSINaz1uII6gGH4o="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-emitter": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.2.2.tgz",
+      "integrity": "sha1-yB43JOtVQHxaDV7jKZQR9wD1QpE=",
+      "requires": {
+        "es5-ext": "0.9.2"
+      }
+    },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "requires": {
+        "duplexer": "0.1.1",
+        "from": "0.1.7",
+        "map-stream": "0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3.3",
+        "stream-combiner": "0.0.4",
+        "through": "2.3.8"
+      }
+    },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+      "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+      "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+      "requires": {
+        "is-posix-bracket": "0.1.1"
+      }
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "requires": {
+        "fill-range": "2.2.4"
+      }
+    },
+    "expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "requires": {
+        "homedir-polyfill": "1.0.1"
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "requires": {
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+      "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fancy-log": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
+      "requires": {
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
+        "time-stamp": "1.1.0"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "faye-websocket": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.7.3.tgz",
+      "integrity": "sha1-zEB0x/Sk39A69U3WXDVLE1EyzhE=",
+      "requires": {
+        "websocket-driver": "0.7.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "requires": {
+        "is-number": "2.1.0",
+        "isobject": "2.1.0",
+        "randomatic": "3.0.0",
+        "repeat-element": "1.1.2",
+        "repeat-string": "1.6.1"
+      }
+    },
+    "filled-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
+    },
+    "finalhandler": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.2",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
+    },
+    "find-index": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+      "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ="
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "findup-sync": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+      "integrity": "sha1-4KkKRQB1xJRm7lE3MgV1FLgeh4w=",
+      "requires": {
+        "glob": "4.3.5"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.3.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+          "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        }
+      }
+    },
+    "fined": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
+      "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0",
+        "object.pick": "1.3.0",
+        "parse-filepath": "1.0.2"
+      }
+    },
+    "first-chunk-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+      "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04="
+    },
+    "flagged-respawn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
+      "integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c="
+    },
+    "follow-redirects": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.1.tgz",
+      "integrity": "sha512-v9GI1hpaqq1ZZR6pBD1+kI7O24PhDvNGNodjS3MdcEqyrahCp8zbtpv+2B/krUnSmUH80lbAS7MrdeK5IylgKg==",
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+      "requires": {
+        "for-in": "1.0.2"
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "fork-stream": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz",
+      "integrity": "sha1-24Sfznf2cIpfjzhq5TOgkHtUrnA="
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.18"
+      }
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "requires": {
+        "map-cache": "0.2.2"
+      }
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "fs-extra": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.24.0.tgz",
+      "integrity": "sha1-1OQ0KpZnXLeEZjOmCZJJMytTmVI=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "requires": {
+            "graceful-fs": "4.1.11"
+          }
+        }
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "optional": true,
+      "requires": {
+        "nan": "2.10.0",
+        "node-pre-gyp": "0.10.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "2.6.9",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.5.1",
+          "bundled": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.21",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": "2.1.2"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minipass": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "minizlib": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "minipass": "2.2.4"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.2.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.10.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.3",
+          "bundled": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.1.10",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.1",
+          "bundled": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "3.0.2",
+          "bundled": true
+        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+      "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "inherits": "2.0.3",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
+      }
+    },
+    "gaze": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.2.tgz",
+      "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
+      "requires": {
+        "globule": "0.1.0"
+      }
+    },
+    "get-caller-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+      "requires": {
+        "glob-parent": "2.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+      "requires": {
+        "is-glob": "2.0.1"
+      }
+    },
+    "glob-stream": {
+      "version": "3.1.18",
+      "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+      "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
+      "requires": {
+        "glob": "4.5.3",
+        "glob2base": "0.0.12",
+        "minimatch": "2.0.10",
+        "ordered-read-streams": "0.1.0",
+        "through2": "0.6.5",
+        "unique-stream": "1.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "glob-watcher": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+      "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
+      "requires": {
+        "gaze": "0.5.2"
+      }
+    },
+    "glob2base": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+      "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
+      "requires": {
+        "find-index": "0.1.1"
+      }
+    },
+    "global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "requires": {
+        "global-prefix": "1.0.2",
+        "is-windows": "1.0.2",
+        "resolve-dir": "1.0.1"
+      }
+    },
+    "global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "homedir-polyfill": "1.0.1",
+        "ini": "1.3.5",
+        "is-windows": "1.0.2",
+        "which": "1.3.1"
+      }
+    },
+    "globby": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+      "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "6.0.4",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "globule": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+      "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
+      "requires": {
+        "glob": "3.1.21",
+        "lodash": "1.0.2",
+        "minimatch": "0.2.14"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "3.1.21",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+          "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
+          "requires": {
+            "graceful-fs": "1.2.3",
+            "inherits": "1.0.2",
+            "minimatch": "0.2.14"
+          }
+        },
+        "graceful-fs": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q="
+        },
+        "inherits": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.2.tgz",
+          "integrity": "sha1-ykMJ2t7mtUzAuNJH6NfHoJdb3Js="
+        },
+        "lodash": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+          "integrity": "sha1-j1dWDIO1n8JwvT1WG2kAQ0MOJVE="
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+          "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        }
+      }
+    },
+    "glogg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+      "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
+      "requires": {
+        "sparkles": "1.0.1"
+      }
+    },
+    "gogo-shell": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/gogo-shell/-/gogo-shell-0.0.5.tgz",
+      "integrity": "sha1-o3U5wDvym29jfbvK+aTTRPAWZwc=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "gogo-shell-helper": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/gogo-shell-helper/-/gogo-shell-helper-0.0.8.tgz",
+      "integrity": "sha1-zxAH5+/bzB000fSqR9qjh1Ly3U0=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.10"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
+      }
+    },
+    "got": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "requires": {
+        "@sindresorhus/is": "0.7.0",
+        "cacheable-request": "2.1.4",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "into-stream": "3.1.0",
+        "is-retry-allowed": "1.1.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "mimic-response": "1.0.1",
+        "p-cancelable": "0.4.1",
+        "p-timeout": "2.0.1",
+        "pify": "3.0.0",
+        "safe-buffer": "5.1.2",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "3.0.0",
+        "url-to-options": "1.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "gulp": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
+      "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
+      "requires": {
+        "archy": "1.0.0",
+        "chalk": "1.1.3",
+        "deprecated": "0.0.1",
+        "gulp-util": "3.0.8",
+        "interpret": "1.1.0",
+        "liftoff": "2.5.0",
+        "minimist": "1.2.0",
+        "orchestrator": "0.3.8",
+        "pretty-hrtime": "1.0.3",
+        "semver": "4.3.6",
+        "tildify": "1.2.0",
+        "v8flags": "2.1.1",
+        "vinyl-fs": "0.3.14"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "4.3.6",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+          "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto="
+        }
+      }
+    },
+    "gulp-concat": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
+      "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
+      "requires": {
+        "concat-with-sourcemaps": "1.1.0",
+        "through2": "2.0.3",
+        "vinyl": "2.2.0"
+      }
+    },
+    "gulp-debug": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gulp-debug/-/gulp-debug-2.1.2.tgz",
+      "integrity": "sha1-L1/l9kvNH0zxicFg4IDIrQZUMJQ=",
+      "requires": {
+        "chalk": "1.1.3",
+        "gulp-util": "3.0.8",
+        "object-assign": "4.1.1",
+        "plur": "2.1.2",
+        "stringify-object": "2.4.0",
+        "through2": "2.0.3",
+        "tildify": "1.2.0"
+      }
+    },
+    "gulp-filter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-2.0.2.tgz",
+      "integrity": "sha1-HOsdET7plCzt1J9YY7Qr5EvHzSw=",
+      "requires": {
+        "gulp-util": "3.0.8",
+        "merge-stream": "0.1.8",
+        "multimatch": "2.1.0",
+        "plexer": "0.0.3",
+        "through2": "0.6.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "gulp-help": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/gulp-help/-/gulp-help-1.6.1.tgz",
+      "integrity": "sha1-Jh2xhuGDl/7z9qLCLpwxW/qIrgw=",
+      "requires": {
+        "chalk": "1.1.3",
+        "object-assign": "3.0.0"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
+      }
+    },
+    "gulp-if": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-2.0.2.tgz",
+      "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
+      "requires": {
+        "gulp-match": "1.0.3",
+        "ternary-stream": "2.0.1",
+        "through2": "2.0.3"
+      }
+    },
+    "gulp-inject": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-inject/-/gulp-inject-2.2.0.tgz",
+      "integrity": "sha1-QN/REAW69rkYHvp3awf9S1JJZJY=",
+      "requires": {
+        "event-stream": "3.3.4",
+        "gulp-util": "3.0.8"
+      }
+    },
+    "gulp-insert": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-insert/-/gulp-insert-0.5.0.tgz",
+      "integrity": "sha1-MjE/E+SiPPWsylzl8MCAkjx3hgI=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "streamqueue": "0.0.6"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "gulp-liferay-r2-css": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/gulp-liferay-r2-css/-/gulp-liferay-r2-css-0.0.2.tgz",
+      "integrity": "sha1-HSVfV/uu6j0wAtXX6Qvq2lEk32c=",
+      "requires": {
+        "gulp-util": "3.0.8",
+        "liferay-r2": "0.4.4",
+        "through2": "2.0.3"
+      }
+    },
+    "gulp-livereload": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/gulp-livereload/-/gulp-livereload-3.8.1.tgz",
+      "integrity": "sha1-APdEstdJ0+njdGWJyKRKysd5tQ8=",
+      "requires": {
+        "chalk": "0.5.1",
+        "debug": "2.6.9",
+        "event-stream": "3.3.4",
+        "gulp-util": "3.0.8",
+        "lodash.assign": "3.2.0",
+        "mini-lr": "0.1.9"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+        }
+      }
+    },
+    "gulp-load-plugins": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-0.8.1.tgz",
+      "integrity": "sha1-CoJh0Fnf3ckY/aQGyCMucvo00uo=",
+      "requires": {
+        "findup-sync": "0.2.1",
+        "multimatch": "2.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "requires": {
+            "brace-expansion": "1.1.11"
+          }
+        },
+        "multimatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "integrity": "sha1-xa2kJTV7dEulSELr3OHI8L5UK28=",
+          "requires": {
+            "array-differ": "1.0.0",
+            "array-union": "1.0.2",
+            "minimatch": "2.0.10"
+          }
+        }
+      }
+    },
+    "gulp-match": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-1.0.3.tgz",
+      "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
+    "gulp-plumber": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-0.6.6.tgz",
+      "integrity": "sha1-n5hGpRPHDQMhbOeiqM5v1aP8MXU=",
+      "requires": {
+        "gulp-util": "3.0.8",
+        "through2": "0.6.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "gulp-prompt": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/gulp-prompt/-/gulp-prompt-0.1.2.tgz",
+      "integrity": "sha1-BsmZvedk4++sYCJTbMK7Aiq4N1A=",
+      "requires": {
+        "event-stream": "3.0.20",
+        "inquirer": "0.3.5"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "event-stream": {
+          "version": "3.0.20",
+          "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.0.20.tgz",
+          "integrity": "sha1-A4u7LqnqkDhbJvvBhU0LU58qvqM=",
+          "requires": {
+            "duplexer": "0.1.1",
+            "from": "0.1.7",
+            "map-stream": "0.0.7",
+            "pause-stream": "0.0.11",
+            "split": "0.2.10",
+            "stream-combiner": "0.0.4",
+            "through": "2.3.8"
+          }
+        },
+        "inquirer": {
+          "version": "0.3.5",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.3.5.tgz",
+          "integrity": "sha1-p4vgZKyavxaBR8Ahaakx2aSDqfY=",
+          "requires": {
+            "async": "0.2.10",
+            "cli-color": "0.2.3",
+            "lodash": "1.2.1",
+            "mute-stream": "0.0.3"
+          }
+        },
+        "lodash": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.2.1.tgz",
+          "integrity": "sha1-7UexbkbwaytAMJto6RY8F+k+owQ="
+        },
+        "map-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+          "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+        },
+        "split": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+          "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+          "requires": {
+            "through": "2.3.8"
+          }
+        }
+      }
+    },
+    "gulp-rename": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.3.0.tgz",
+      "integrity": "sha512-nEuZB7/9i0IZ8AXORTizl2QLP9tcC9uWc/s329zElBLJw1CfOhmMXBxwVlCRKjDyrWuhVP0uBKl61KeQ32TiCg=="
+    },
+    "gulp-replace-task": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/gulp-replace-task/-/gulp-replace-task-0.2.3.tgz",
+      "integrity": "sha1-Qy8kJkrP7T0hBdSpRbBMiqh8CJk=",
+      "requires": {
+        "applause": "0.4.3",
+        "gulp-util": "3.0.8",
+        "through2": "2.0.3"
+      }
+    },
+    "gulp-ruby-sass": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-ruby-sass/-/gulp-ruby-sass-2.1.1.tgz",
+      "integrity": "sha1-6A9lCSEI7kr8tJNgiNxyUzaa3Kw=",
+      "requires": {
+        "convert-source-map": "1.5.1",
+        "cross-spawn": "5.1.0",
+        "dargs": "2.1.0",
+        "each-async": "1.1.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "glob2base": "0.0.12",
+        "gulp-util": "3.0.8",
+        "md5-hex": "1.3.0",
+        "object-assign": "4.1.1",
+        "os-tmpdir": "1.0.2",
+        "path-exists": "2.1.0",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "4.1.3",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
+          }
+        }
+      }
+    },
+    "gulp-sass": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.2.0.tgz",
+      "integrity": "sha512-lIF2rC8LejqVLw5lnL7efLWjOrir/n87icopRNxOMCfz9rE52IXUP9Bgxt/OAWzIsBbNSjVWlbxaHtjDFnPhfQ==",
+      "requires": {
+        "gulp-util": "3.0.8",
+        "lodash.clonedeep": "4.5.0",
+        "node-sass": "4.9.2",
+        "through2": "2.0.3",
+        "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "gulp-sourcemaps": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
+      "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+      "requires": {
+        "convert-source-map": "1.5.1",
+        "graceful-fs": "4.1.11",
+        "strip-bom": "2.0.0",
+        "through2": "2.0.3",
+        "vinyl": "1.2.0"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
+        "vinyl": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
+          "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+          "requires": {
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
+      }
+    },
+    "gulp-storage": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/gulp-storage/-/gulp-storage-1.0.6.tgz",
+      "integrity": "sha1-FmjuOaK8877vbStrfW1tM0X0Etc=",
+      "requires": {
+        "gulp": "3.9.1",
+        "gulp-util": "2.2.20",
+        "lodash": "2.4.2",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
+          }
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
+        "dateformat": {
+          "version": "1.0.12",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "requires": {
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
+          }
+        },
+        "gulp-util": {
+          "version": "2.2.20",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "integrity": "sha1-1xRuVyiRC9jwR6awseVJvCLb1kw=",
+          "requires": {
+            "chalk": "0.5.1",
+            "dateformat": "1.0.12",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.template": "2.4.1",
+            "minimist": "0.2.0",
+            "multipipe": "0.1.2",
+            "through2": "0.5.1",
+            "vinyl": "0.2.3"
+          },
+          "dependencies": {
+            "through2": {
+              "version": "0.5.1",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "integrity": "sha1-390BLrnHAOIyP9M084rGIqs3Lac=",
+              "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "3.0.0"
+              }
+            }
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        },
+        "lodash._reinterpolate": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
+          "integrity": "sha1-TxInqlqHEfxjL1sHofRgequLMiI="
+        },
+        "lodash.escape": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+          "integrity": "sha1-LOEsXghNsKV92l5dHu659dF1o7Q=",
+          "requires": {
+            "lodash._escapehtmlchar": "2.4.1",
+            "lodash._reunescapedhtml": "2.4.1",
+            "lodash.keys": "2.4.1"
+          }
+        },
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "requires": {
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
+          }
+        },
+        "lodash.template": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+          "integrity": "sha1-nmEQB+32KRKal0qzxIuBez4c8g0=",
+          "requires": {
+            "lodash._escapestringchar": "2.4.1",
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.defaults": "2.4.1",
+            "lodash.escape": "2.4.1",
+            "lodash.keys": "2.4.1",
+            "lodash.templatesettings": "2.4.1",
+            "lodash.values": "2.4.1"
+          }
+        },
+        "lodash.templatesettings": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
+          "integrity": "sha1-6nbHXRHrhtTb6JqDiTu4YZKaxpk=",
+          "requires": {
+            "lodash._reinterpolate": "2.4.1",
+            "lodash.escape": "2.4.1"
+          }
+        },
+        "minimist": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
+          "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+        },
+        "vinyl": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+          "integrity": "sha1-vKk4IJWC7FpJrVOKAPofEl5RMlI=",
+          "requires": {
+            "clone-stats": "0.0.1"
+          }
+        },
+        "xtend": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+          "integrity": "sha1-XM50B7r2Qsunvs2laBEcST9ZZlo="
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+      "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-uniq": "1.0.3",
+        "beeper": "1.1.1",
+        "chalk": "1.1.3",
+        "dateformat": "2.2.0",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "has-gulplog": "0.1.0",
+        "lodash._reescape": "3.0.0",
+        "lodash._reevaluate": "3.0.0",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.template": "3.6.2",
+        "minimist": "1.2.0",
+        "multipipe": "0.1.2",
+        "object-assign": "3.0.0",
+        "replace-ext": "0.0.1",
+        "through2": "2.0.3",
+        "vinyl": "0.5.3"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+        },
+        "vinyl": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+          "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+          "requires": {
+            "clone": "1.0.4",
+            "clone-stats": "0.0.1",
+            "replace-ext": "0.0.1"
+          }
+        }
+      }
+    },
+    "gulp-zip": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-zip/-/gulp-zip-3.2.0.tgz",
+      "integrity": "sha1-69GY2ubcLV9E2BRWnI7EIRipPvk=",
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.2",
+        "gulp-util": "3.0.8",
+        "through2": "2.0.3",
+        "yazl": "2.4.3"
+      }
+    },
+    "gulplog": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+      "requires": {
+        "glogg": "1.0.1"
+      }
+    },
+    "handlebars": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.3.tgz",
+      "integrity": "sha1-DgllGi8Ps8lJFgWDcQ1VH5Lm0q0=",
+      "requires": {
+        "optimist": "0.6.1",
+        "source-map": "0.1.43",
+        "uglify-js": "2.3.6"
+      }
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-binary2": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+      "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "requires": {
+        "isarray": "2.0.1"
+      }
+    },
+    "has-cors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+    },
+    "has-gulplog": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+      "requires": {
+        "sparkles": "1.0.1"
+      }
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw=="
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "requires": {
+        "has-symbol-support-x": "1.4.2"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "requires": {
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "requires": {
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "requires": {
+            "is-buffer": "1.1.6"
+          }
+        }
+      }
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+      "requires": {
+        "boom": "2.10.1",
+        "cryptiles": "2.0.5",
+        "hoek": "2.16.3",
+        "sntp": "1.0.9"
+      }
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
+    },
+    "homedir-polyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
+      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "requires": {
+        "parse-passwd": "1.0.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+    },
+    "http": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/http/-/http-0.0.0.tgz",
+      "integrity": "sha1-huYybSnF0Dnen6xYSkVon5KfT3I="
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": "1.5.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
+      }
+    },
+    "http-parser-js": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc="
+    },
+    "http-proxy": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+      "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
+      "requires": {
+        "eventemitter3": "1.2.0",
+        "requires-port": "1.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+      "requires": {
+        "assert-plus": "0.2.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
+      }
+    },
+    "https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha1-PDfHrhqO65ZpBKKtHpdaGUt+06Q="
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+      "integrity": "sha1-4g/146KvwmkDILbcVSaCqcf631E="
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.10",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ="
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "requires": {
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
+      }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+    },
+    "irregular-plurals": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
+      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y="
+    },
+    "is-absolute": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+      "requires": {
+        "is-relative": "1.0.0",
+        "is-windows": "1.0.2"
+      }
+    },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+      "requires": {
+        "binary-extensions": "1.11.0"
+      }
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "requires": {
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+        }
+      }
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+      "requires": {
+        "is-primitive": "2.0.0"
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+      "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+      "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+      "requires": {
+        "is-extglob": "1.0.0"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "is-number-like": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+      "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+      "requires": {
+        "lodash.isfinite": "3.3.2"
+      }
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
+    },
+    "is-relative": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+      "requires": {
+        "is-unc-path": "1.0.0"
+      }
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "is-unc-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
+    "isarray": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+      "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "requires": {
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
+      }
+    },
+    "js-base64": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.8.tgz",
+      "integrity": "sha512-hm2nYpDrwoO/OzBhdcqs/XGT6XjSuSSCVEpia+Kl2J6x4CYt5hISlVL/AYU1khoDXv0AQVgxtdJySb9gjAn56Q=="
+    },
+    "js-yaml": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "requires": {
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "1.1.6"
+      }
+    },
+    "latest-version": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "requires": {
+        "package-json": "2.4.0"
+      },
+      "dependencies": {
+        "duplexer2": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+          "requires": {
+            "readable-stream": "2.3.6"
+          }
+        },
+        "got": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+          "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+          "requires": {
+            "create-error-class": "3.0.2",
+            "duplexer2": "0.1.4",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.1.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "node-status-codes": "1.0.0",
+            "object-assign": "4.1.1",
+            "parse-json": "2.2.0",
+            "pinkie-promise": "2.0.1",
+            "read-all-stream": "3.1.0",
+            "readable-stream": "2.3.6",
+            "timed-out": "3.1.3",
+            "unzip-response": "1.0.2",
+            "url-parse-lax": "1.0.0"
+          }
+        },
+        "package-json": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+          "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+          "requires": {
+            "got": "5.7.1",
+            "registry-auth-token": "3.3.2",
+            "registry-url": "3.1.0",
+            "semver": "5.5.0"
+          }
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+        },
+        "timed-out": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+          "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc="
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "requires": {
+            "prepend-http": "1.0.4"
+          }
+        }
+      }
+    },
+    "lazy-req": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w="
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "1.0.0"
+      }
+    },
+    "liferay-css-parse": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/liferay-css-parse/-/liferay-css-parse-1.7.1.tgz",
+      "integrity": "sha1-wHUMwPBkXSGQ7u/uhFtvyxVPPkU="
+    },
+    "liferay-frontend-common-css": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/liferay-frontend-common-css/-/liferay-frontend-common-css-1.0.4.tgz",
+      "integrity": "sha1-5Nc+QGAg2QfJCbyssnAKUvocfxY="
+    },
+    "liferay-frontend-theme-classic-web": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-classic-web/-/liferay-frontend-theme-classic-web-2.0.2.tgz",
+      "integrity": "sha1-mFrY147m7HwOX6YaFGXc76NuG1o="
+    },
+    "liferay-frontend-theme-styled": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-2.0.28.tgz",
+      "integrity": "sha1-IQx2gcjHhScwHcdk3GhS11C6Crg="
+    },
+    "liferay-frontend-theme-unstyled": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-2.1.16.tgz",
+      "integrity": "sha1-KPaqFP1DqDfSwYpcKe5p8g1vdeo="
+    },
+    "liferay-plugin-node-tasks": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/liferay-plugin-node-tasks/-/liferay-plugin-node-tasks-1.0.11.tgz",
+      "integrity": "sha1-gs8ADbkfpO44/x1HDvSNVQp9Uxw=",
+      "requires": {
+        "async": "2.6.1",
+        "gogo-shell": "0.0.5",
+        "gulp": "3.9.1",
+        "gulp-help": "1.6.1",
+        "gulp-storage": "1.0.6",
+        "gulp-util": "3.0.8",
+        "gulp-zip": "3.2.0",
+        "inquirer": "0.12.0",
+        "lodash": "4.17.10",
+        "minimist": "1.2.0",
+        "require-directory": "2.1.1",
+        "run-sequence": "1.2.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        }
+      }
+    },
+    "liferay-r2": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/liferay-r2/-/liferay-r2-0.4.4.tgz",
+      "integrity": "sha1-zAAFnv37icywIk603cfyc53EJ/s=",
+      "requires": {
+        "css-stringify": "1.4.1",
+        "liferay-css-parse": "1.7.1"
+      }
+    },
+    "liferay-theme-deps-7.0": {
+      "version": "8.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/liferay-theme-deps-7.0/-/liferay-theme-deps-7.0-8.0.0-beta.1.tgz",
+      "integrity": "sha512-hZvyNx+AR6jpJ8aOzLjJK6vVzMizK4GC1oDctz8+RATuadM9IMSjdpi8CIcRxZFfWilxR2qzbE+52id9j4D+jQ==",
+      "requires": {
+        "compass-mixins": "0.12.10",
+        "gulp-ruby-sass": "2.1.1",
+        "gulp-sass": "3.2.0",
+        "liferay-frontend-common-css": "1.0.4",
+        "liferay-frontend-theme-classic-web": "2.0.2",
+        "liferay-frontend-theme-styled": "2.0.28",
+        "liferay-frontend-theme-unstyled": "2.1.16",
+        "liferay-theme-deps-normalize": "8.0.0-beta.1"
+      }
+    },
+    "liferay-theme-deps-7.1": {
+      "version": "8.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/liferay-theme-deps-7.1/-/liferay-theme-deps-7.1-8.0.0-beta.1.tgz",
+      "integrity": "sha512-H3bfjaZ3LuxNCx/mxqbtLWHz0iToDPODYulcu8Fy7iYeQEDZM30Bu5deTWDBqAZ8JXl60QfYTaQxgVcd+/ZQBA==",
+      "requires": {
+        "compass-mixins": "0.12.10",
+        "gulp-ruby-sass": "2.1.1",
+        "gulp-sass": "3.2.0",
+        "liferay-frontend-common-css": "1.0.4",
+        "liferay-frontend-theme-classic-web": "2.0.2",
+        "liferay-frontend-theme-styled": "3.0.0-alpha.1521181585788",
+        "liferay-frontend-theme-unstyled": "3.0.0-alpha.1521181854318",
+        "liferay-theme-deps-normalize": "1.0.0"
+      },
+      "dependencies": {
+        "liferay-frontend-theme-styled": {
+          "version": "3.0.0-alpha.1521181585788",
+          "resolved": "https://registry.npmjs.org/liferay-frontend-theme-styled/-/liferay-frontend-theme-styled-3.0.0-alpha.1521181585788.tgz",
+          "integrity": "sha512-h9l0mN5Z+d+AZEXgGDJL3eMXaUlkiPcUha6v/Z3pUgKDo2BCnYvO6zEQxMZShpc0myNMvrILvOqRQD9oM1thow=="
+        },
+        "liferay-frontend-theme-unstyled": {
+          "version": "3.0.0-alpha.1521181854318",
+          "resolved": "https://registry.npmjs.org/liferay-frontend-theme-unstyled/-/liferay-frontend-theme-unstyled-3.0.0-alpha.1521181854318.tgz",
+          "integrity": "sha512-a2EFLyc/HXGQhpOLMNkH5gug+n70UAixu95YemiPCji9eYDY4xWfCr8UTg7H7cd/BesGMIUO/N/XgYXZLDCi1Q==",
+          "requires": {
+            "clay": "2.0.0-rc.9"
+          }
+        },
+        "liferay-theme-deps-normalize": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/liferay-theme-deps-normalize/-/liferay-theme-deps-normalize-1.0.0.tgz",
+          "integrity": "sha1-ULZ371ujG0iN8IVRBBkxZy/N3z4="
+        }
+      }
+    },
+    "liferay-theme-deps-normalize": {
+      "version": "8.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/liferay-theme-deps-normalize/-/liferay-theme-deps-normalize-8.0.0-beta.1.tgz",
+      "integrity": "sha512-QdOijEEeAEtYaTBSrg5KA5IVhYpFLmzviciFj7CYgp6FQSSHYXv0+21K29TjDpcNLLFUE6uD8V77iyo6nI4cdA=="
+    },
+    "liftoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
+      "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+      "requires": {
+        "extend": "3.0.1",
+        "findup-sync": "2.0.0",
+        "fined": "1.1.0",
+        "flagged-respawn": "1.0.0",
+        "is-plain-object": "2.0.4",
+        "object.map": "1.0.1",
+        "rechoir": "0.6.2",
+        "resolve": "1.8.1"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "requires": {
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "requires": {
+                "is-descriptor": "0.1.6"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "requires": {
+                    "is-buffer": "1.1.6"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "requires": {
+                "is-accessor-descriptor": "0.1.6",
+                "is-data-descriptor": "0.1.4",
+                "kind-of": "5.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "requires": {
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "requires": {
+                "is-descriptor": "1.0.2"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "requires": {
+                "is-extendable": "0.1.1"
+              }
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+          "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+          "requires": {
+            "detect-file": "1.0.0",
+            "is-glob": "3.1.0",
+            "micromatch": "3.1.10",
+            "resolve-dir": "1.0.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "requires": {
+                "is-buffer": "1.1.6"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "requires": {
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
+          }
+        }
+      }
+    },
+    "limiter": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
+      "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw=="
+    },
+    "livereload-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+      "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg=="
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
+      }
+    },
+    "localtunnel": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
+      "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
+      "requires": {
+        "axios": "0.17.1",
+        "debug": "2.6.8",
+        "openurl": "1.1.1",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
+    },
+    "lodash._basetostring": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
+    },
+    "lodash._basevalues": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
+    },
+    "lodash._escapehtmlchar": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+      "integrity": "sha1-32fDu2t+jh6DGrSL+geVuSr+iZ0=",
+      "requires": {
+        "lodash._htmlescapes": "2.4.1"
+      }
+    },
+    "lodash._escapestringchar": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
+      "integrity": "sha1-7P4iYYoq3lC/7qQ5N+Ud9m8O23I="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._htmlescapes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
+      "integrity": "sha1-MtFL8IRLbeb4tioFG09nwii2JMs="
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
+    },
+    "lodash._isnative": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
+      "integrity": "sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw="
+    },
+    "lodash._objecttypes": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
+      "integrity": "sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE="
+    },
+    "lodash._reescape": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
+    },
+    "lodash._reevaluate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash._reunescapedhtml": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+      "integrity": "sha1-dHxPxAED6zu4oJduVx96JlnpO6c=",
+      "requires": {
+        "lodash._htmlescapes": "2.4.1",
+        "lodash.keys": "2.4.1"
+      },
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "requires": {
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
+          }
+        }
+      }
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
+    },
+    "lodash._shimkeys": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+      "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
+      "requires": {
+        "lodash._objecttypes": "2.4.1"
+      }
+    },
+    "lodash.assign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.defaults": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+      "integrity": "sha1-p+iIXwXmiFEUS24SqPNngCa8TFQ=",
+      "requires": {
+        "lodash._objecttypes": "2.4.1",
+        "lodash.keys": "2.4.1"
+      },
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "requires": {
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
+          }
+        }
+      }
+    },
+    "lodash.escape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+      "requires": {
+        "lodash._root": "3.0.1"
+      }
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
+    },
+    "lodash.isobject": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+      "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
+      "requires": {
+        "lodash._objecttypes": "2.4.1"
+      }
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "lodash.mergewith": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
+      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ=="
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
+    },
+    "lodash.template": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+      "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash._basetostring": "3.0.1",
+        "lodash._basevalues": "3.0.0",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0",
+        "lodash.keys": "3.1.2",
+        "lodash.restparam": "3.6.1",
+        "lodash.templatesettings": "3.1.1"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+      "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.escape": "3.2.0"
+      }
+    },
+    "lodash.values": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
+      "integrity": "sha1-q/UUQ2s8twUAFieXjLzzCxKA7qQ=",
+      "requires": {
+        "lodash.keys": "2.4.1"
+      },
+      "dependencies": {
+        "lodash.keys": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+          "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
+          "requires": {
+            "lodash._isnative": "2.4.1",
+            "lodash._shimkeys": "2.4.1",
+            "lodash.isobject": "2.4.1"
+          }
+        }
+      }
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "requires": {
+        "currently-unhandled": "0.4.1",
+        "signal-exit": "3.0.2"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
+    },
+    "lru-cache": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "requires": {
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
+      }
+    },
+    "make-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+      "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+      "requires": {
+        "kind-of": "6.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ="
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "requires": {
+        "object-visit": "1.0.1"
+      }
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+    },
+    "md5-hex": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
+      "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+      "requires": {
+        "md5-o-matic": "0.1.1"
+      }
+    },
+    "md5-o-matic": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memoizee": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.2.6.tgz",
+      "integrity": "sha1-u0WnrQJTAILxYSZx2rNSGc0uB0E=",
+      "requires": {
+        "es5-ext": "0.9.2",
+        "event-emitter": "0.2.2",
+        "next-tick": "0.1.0"
+      }
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "requires": {
+        "camelcase-keys": "2.1.0",
+        "decamelize": "1.2.0",
+        "loud-rejection": "1.6.0",
+        "map-obj": "1.0.1",
+        "minimist": "1.2.0",
+        "normalize-package-data": "2.4.0",
+        "object-assign": "4.1.1",
+        "read-pkg-up": "1.0.1",
+        "redent": "1.0.0",
+        "trim-newlines": "1.0.0"
+      }
+    },
+    "merge-stream": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.8.tgz",
+      "integrity": "sha1-SKB7O0oSHXSj7b/c20sIrb8CQLE=",
+      "requires": {
+        "through2": "0.6.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+      "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+      "requires": {
+        "arr-diff": "2.0.0",
+        "array-unique": "0.2.1",
+        "braces": "1.8.5",
+        "expand-brackets": "0.1.5",
+        "extglob": "0.3.2",
+        "filename-regex": "2.0.1",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1",
+        "kind-of": "3.2.2",
+        "normalize-path": "2.1.1",
+        "object.omit": "2.0.1",
+        "parse-glob": "3.0.4",
+        "regex-cache": "0.4.4"
+      }
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "requires": {
+        "mime-db": "1.33.0"
+      }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
+    },
+    "mini-lr": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/mini-lr/-/mini-lr-0.1.9.tgz",
+      "integrity": "sha1-AhmdJzR5U9H9HW297UJh8Yey0PY=",
+      "requires": {
+        "body-parser": "1.14.2",
+        "debug": "2.6.9",
+        "faye-websocket": "0.7.3",
+        "livereload-js": "2.3.0",
+        "parseurl": "1.3.2",
+        "qs": "2.2.5"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.5.tgz",
+          "integrity": "sha1-EIirr53MCuWuRbcJ5sa1iIsjkjw="
+        }
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "requires": {
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "requires": {
+            "is-plain-object": "2.0.4"
+          }
+        }
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multimatch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
+      "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
+      "requires": {
+        "array-differ": "1.0.0",
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "minimatch": "3.0.4"
+      }
+    },
+    "multipipe": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+      "requires": {
+        "duplexer2": "0.0.2"
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.3.tgz",
+      "integrity": "sha1-8JwJDTM7MGP2Fcu8ynGzSYk/AVI="
+    },
+    "nan": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "requires": {
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.2",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "natives": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "next-tick": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.1.0.tgz",
+      "integrity": "sha1-GRLM6OubaX1kD7upT48A3sO5Qlk="
+    },
+    "node-bourbon": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/node-bourbon/-/node-bourbon-4.2.3.tgz",
+      "integrity": "sha1-vuEU9IBbXrK10nRHC8TTpskEnMQ=",
+      "requires": {
+        "bourbon": "4.2.3"
+      }
+    },
+    "node-gyp": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
+      "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
+      "requires": {
+        "fstream": "1.0.11",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "npmlog": "4.1.2",
+        "osenv": "0.1.5",
+        "request": "2.81.0",
+        "rimraf": "2.6.2",
+        "semver": "5.3.0",
+        "tar": "2.2.1",
+        "which": "1.3.1"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.2",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+        }
+      }
+    },
+    "node-sass": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
+      "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
+      "requires": {
+        "async-foreach": "0.1.3",
+        "chalk": "1.1.3",
+        "cross-spawn": "3.0.1",
+        "gaze": "1.1.3",
+        "get-stdin": "4.0.1",
+        "glob": "7.1.2",
+        "in-publish": "2.0.0",
+        "lodash.assign": "4.2.0",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.mergewith": "4.6.1",
+        "meow": "3.7.0",
+        "mkdirp": "0.5.1",
+        "nan": "2.10.0",
+        "node-gyp": "3.7.0",
+        "npmlog": "4.1.2",
+        "request": "2.87.0",
+        "sass-graph": "2.2.4",
+        "stdout-stream": "1.4.0",
+        "true-case-path": "1.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
+          "requires": {
+            "lru-cache": "4.1.3",
+            "which": "1.3.1"
+          }
+        },
+        "gaze": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+          "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+          "requires": {
+            "globule": "1.2.1"
+          }
+        },
+        "globule": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+          "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+          "requires": {
+            "glob": "7.1.2",
+            "lodash": "4.17.10",
+            "minimatch": "3.0.4"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+        }
+      }
+    },
+    "node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8="
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.0",
+        "validate-npm-package-license": "3.0.3"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "requires": {
+        "prepend-http": "2.0.0",
+        "query-string": "5.1.1",
+        "sort-keys": "2.0.0"
+      }
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "npms-keyword": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/npms-keyword/-/npms-keyword-1.2.0.tgz",
+      "integrity": "sha512-Xd5ImY4uzGtltaJDTRcMk5VWApMnu1ayqGlHhiPFelP9K3a9IJ7hoMItf7qyqG7iYE/Rze96Edx3Ie99HqnAfQ==",
+      "requires": {
+        "got": "8.3.2",
+        "http": "0.0.0",
+        "https": "1.0.0",
+        "registry-url": "3.1.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-component": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "requires": {
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "object-path": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
+      "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU="
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "object.defaults": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "requires": {
+        "array-each": "1.0.1",
+        "array-slice": "1.1.0",
+        "for-own": "1.0.0",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "object.map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "requires": {
+        "for-own": "1.0.0",
+        "make-iterator": "1.0.1"
+      },
+      "dependencies": {
+        "for-own": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+          "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        }
+      }
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+      "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+      "requires": {
+        "for-own": "0.1.5",
+        "is-extendable": "0.1.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+    },
+    "openurl": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+      "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
+    },
+    "opn": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "0.0.10",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+        }
+      }
+    },
+    "orchestrator": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.8.tgz",
+      "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
+      "requires": {
+        "end-of-stream": "0.1.5",
+        "sequencify": "0.0.7",
+        "stream-consume": "0.1.1"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+          "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
+          "requires": {
+            "once": "1.3.3"
+          }
+        },
+        "once": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        }
+      }
+    },
+    "ordered-read-streams": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+      "integrity": "sha1-/VZamvjrRHO6abbtijQ1LLVS8SY="
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "requires": {
+        "lcid": "1.0.0"
+      }
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha1-a2LDeRz3kJ6jXtRuF2WLtBfLORc="
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "requires": {
+        "p-finally": "1.0.0"
+      }
+    },
+    "package-json": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-5.0.0.tgz",
+      "integrity": "sha512-EeHQFFTlEmLrkIQoxbE9w0FuAWHoc1XpthDqnZ/i9keOt701cteyXwAxQFLpVqVjj3feh2TodkihjLaRUtIgLg==",
+      "requires": {
+        "got": "8.3.2",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
+      }
+    },
+    "parse-filepath": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "requires": {
+        "is-absolute": "1.0.0",
+        "map-cache": "0.2.2",
+        "path-root": "0.1.1"
+      }
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+      "requires": {
+        "glob-base": "0.3.0",
+        "is-dotfile": "1.0.3",
+        "is-extglob": "1.0.0",
+        "is-glob": "2.0.1"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.2"
+      }
+    },
+    "parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
+    "parseqs": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+      "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseuri": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+      "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "requires": {
+        "better-assert": "1.0.2"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
+    },
+    "path-root": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "requires": {
+        "path-root-regex": "0.1.2"
+      }
+    },
+    "path-root-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0="
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "plexer": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/plexer/-/plexer-0.0.3.tgz",
+      "integrity": "sha1-M00dfNYjJGVBfppmNkkB8pIw9TE=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "plugin-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "requires": {
+        "ansi-colors": "1.1.0",
+        "arr-diff": "4.0.0",
+        "arr-union": "3.1.0",
+        "extend-shallow": "3.0.2"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+        }
+      }
+    },
+    "plur": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
+      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "requires": {
+        "irregular-plurals": "1.4.0"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+      "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
+      "requires": {
+        "async": "1.5.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
+    "portscanner": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+      "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+      "requires": {
+        "async": "1.5.2",
+        "is-number-like": "1.0.8"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "pretty-hrtime": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "qs": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+      "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
+      }
+    },
+    "randomatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+      "requires": {
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      }
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "requires": {
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "requires": {
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "1.1.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "requires": {
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        }
+      }
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "minimatch": "3.0.4",
+        "readable-stream": "2.3.6",
+        "set-immediate-shim": "1.0.1"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      },
+      "dependencies": {
+        "mute-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+          "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+        }
+      }
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "1.8.1"
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "requires": {
+        "indent-string": "2.1.0",
+        "strip-indent": "1.0.1"
+      }
+    },
+    "regex-cache": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "requires": {
+        "is-equal-shallow": "0.1.3"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "requires": {
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "requires": {
+        "rc": "1.2.8",
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "requires": {
+        "rc": "1.2.8"
+      }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+      "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "replace-ext": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
+    },
+    "request": {
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.1.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "form-data": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.6",
+            "mime-types": "2.1.18"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "5.5.2",
+            "har-schema": "2.0.0"
+          }
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.14.2"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        }
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+      "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "requires": {
+        "expand-tilde": "2.0.2",
+        "global-modules": "1.0.0"
+      }
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+    },
+    "resp-modifier": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+      "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+      "requires": {
+        "debug": "2.6.9",
+        "minimatch": "3.0.4"
+      }
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "requires": {
+        "lowercase-keys": "1.0.1"
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "roolz": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/roolz/-/roolz-1.0.2.tgz",
+      "integrity": "sha1-9GScCTA2bsSxs12cbFr9ofHpGM8=",
+      "requires": {
+        "drip": "1.4.0",
+        "lodash": "3.10.1",
+        "string-sub": "0.0.1"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "run-sequence": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
+      "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
+      "requires": {
+        "chalk": "1.1.3",
+        "gulp-util": "3.0.8"
+      }
+    },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "requires": {
+        "ret": "0.1.15"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+      "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
+      "requires": {
+        "glob": "7.1.2",
+        "lodash": "4.17.10",
+        "scss-tokenizer": "0.2.3",
+        "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "requires": {
+        "js-base64": "2.4.8",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "requires": {
+        "semver": "5.5.0"
+      }
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.3",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "sequencify": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
+      "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw="
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "requires": {
+        "accepts": "1.3.5",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "1.0.3",
+        "http-errors": "1.6.3",
+        "mime-types": "2.1.18",
+        "parseurl": "1.3.2"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "1.0.2",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "requires": {
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        }
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
+    },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "requires": {
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.2",
+        "use": "3.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "requires": {
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "requires": {
+            "is-descriptor": "1.0.2"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "requires": {
+            "kind-of": "6.0.2"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "requires": {
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.2"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+      "requires": {
+        "hoek": "2.16.3"
+      }
+    },
+    "socket.io": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+      "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+      "requires": {
+        "debug": "3.1.0",
+        "engine.io": "3.2.0",
+        "has-binary2": "1.0.3",
+        "socket.io-adapter": "1.1.1",
+        "socket.io-client": "2.1.1",
+        "socket.io-parser": "3.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "engine.io-client": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+          "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+          "requires": {
+            "component-emitter": "1.2.1",
+            "component-inherit": "0.0.3",
+            "debug": "3.1.0",
+            "engine.io-parser": "2.1.2",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "ws": "3.3.3",
+            "xmlhttprequest-ssl": "1.5.5",
+            "yeast": "0.1.2"
+          }
+        },
+        "socket.io-client": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+          "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+          "requires": {
+            "backo2": "1.0.2",
+            "base64-arraybuffer": "0.1.5",
+            "component-bind": "1.0.0",
+            "component-emitter": "1.2.1",
+            "debug": "3.1.0",
+            "engine.io-client": "3.2.1",
+            "has-binary2": "1.0.3",
+            "has-cors": "1.1.0",
+            "indexof": "0.0.1",
+            "object-component": "0.0.3",
+            "parseqs": "0.0.5",
+            "parseuri": "0.0.5",
+            "socket.io-parser": "3.2.0",
+            "to-array": "0.1.4"
+          }
+        },
+        "socket.io-parser": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+          "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+          "requires": {
+            "component-emitter": "1.2.1",
+            "debug": "3.1.0",
+            "isarray": "2.0.1"
+          }
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+      "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+    },
+    "socket.io-client": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+      "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+      "requires": {
+        "backo2": "1.0.2",
+        "base64-arraybuffer": "0.1.5",
+        "component-bind": "1.0.0",
+        "component-emitter": "1.2.1",
+        "debug": "2.6.9",
+        "engine.io-client": "3.1.6",
+        "has-cors": "1.1.0",
+        "indexof": "0.0.1",
+        "object-component": "0.0.3",
+        "parseqs": "0.0.5",
+        "parseuri": "0.0.5",
+        "socket.io-parser": "3.1.3",
+        "to-array": "0.1.4"
+      }
+    },
+    "socket.io-parser": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
+      "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "debug": "3.1.0",
+        "has-binary2": "1.0.3",
+        "isarray": "2.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "requires": {
+        "atob": "2.1.1",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
+      }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+    },
+    "sparkles": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+      "integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "os-shim": "0.1.3"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+      "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "2.1.0",
+        "spdx-license-ids": "3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+    },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "requires": {
+        "extend-shallow": "3.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sshpk": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "requires": {
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "requires": {
+            "is-descriptor": "0.1.6"
+          }
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stdout-stream": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
+      "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
+      "requires": {
+        "readable-stream": "2.3.6"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "requires": {
+        "duplexer": "0.1.1"
+      }
+    },
+    "stream-consume": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.1.tgz",
+      "integrity": "sha512-tNa3hzgkjEP7XbCkbRXe1jpg+ievoa0O4SCFlMOYEscGSS4JJsckGL8swUyAa/ApGU3Ae4t6Honor4HhL+tRyg=="
+    },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
+    "stream-throttle": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+      "requires": {
+        "commander": "2.16.0",
+        "limiter": "1.1.3"
+      }
+    },
+    "streamqueue": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.0.6.tgz",
+      "integrity": "sha1-ZvX17JTpuK8knkrsLdH3Qb/pTeM=",
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "string-sub": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/string-sub/-/string-sub-0.0.1.tgz",
+      "integrity": "sha1-Z8lZrDoU5c/igP7wi0IcJAUOqk0="
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "stringify-object": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-2.4.0.tgz",
+      "integrity": "sha1-xi0RAj6yH+LZsIe+A5om3zsioJ0=",
+      "requires": {
+        "is-plain-obj": "1.1.0",
+        "is-regexp": "1.0.0"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA=="
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "requires": {
+        "get-stdin": "4.0.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "tar": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+      "requires": {
+        "block-stream": "0.0.9",
+        "fstream": "1.0.11",
+        "inherits": "2.0.3"
+      }
+    },
+    "tea-concat": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tea-concat/-/tea-concat-0.1.0.tgz",
+      "integrity": "sha1-6i6QdAD914pjNM4CD6PGlQLZnoQ="
+    },
+    "ternary-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-2.0.1.tgz",
+      "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
+      "requires": {
+        "duplexify": "3.6.0",
+        "fork-stream": "0.0.4",
+        "merge-stream": "1.0.1",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "merge-stream": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+          "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+          "requires": {
+            "readable-stream": "2.3.6"
+          }
+        }
+      }
+    },
+    "tfunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
+      "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "object-path": "0.9.2"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
+      }
+    },
+    "tildify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.2.0.tgz",
+      "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "time-stamp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
+    "to-array": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+    },
+    "to-int": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/to-int/-/to-int-0.1.0.tgz",
+      "integrity": "sha1-OuACfPEcfyI3+DADtj77dkMVYW0="
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "requires": {
+        "kind-of": "3.2.2"
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "requires": {
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "requires": {
+        "is-number": "3.0.0",
+        "repeat-string": "1.6.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    },
+    "true-case-path": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.2.tgz",
+      "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
+      "requires": {
+        "glob": "6.0.4"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.18"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "uglify-js": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+      "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
+      "optional": true,
+      "requires": {
+        "async": "0.2.10",
+        "optimist": "0.3.7",
+        "source-map": "0.1.43"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "optional": true
+        },
+        "optimist": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+          "optional": true,
+          "requires": {
+            "wordwrap": "0.0.3"
+          }
+        }
+      }
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "requires": {
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "requires": {
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "to-object-path": "0.3.0"
+          }
+        }
+      }
+    },
+    "unique-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
+      "integrity": "sha1-1ZpKdUJ0R9mqbJHnAmP40mpLEEs="
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "requires": {
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "requires": {
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+    },
+    "update-notifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+      "requires": {
+        "boxen": "0.6.0",
+        "chalk": "1.1.3",
+        "configstore": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "2.0.0",
+        "lazy-req": "1.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "2.0.0"
+      }
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "requires": {
+        "prepend-http": "2.0.0"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k="
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "requires": {
+        "user-home": "1.1.1"
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+      "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "requires": {
+        "spdx-correct": "3.0.0",
+        "spdx-expression-parse": "3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        }
+      }
+    },
+    "vinyl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+      "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+      "requires": {
+        "clone": "2.1.1",
+        "clone-buffer": "1.0.0",
+        "clone-stats": "1.0.0",
+        "cloneable-readable": "1.1.2",
+        "remove-trailing-separator": "1.1.0",
+        "replace-ext": "1.0.0"
+      }
+    },
+    "vinyl-fs": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.14.tgz",
+      "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
+      "requires": {
+        "defaults": "1.0.3",
+        "glob-stream": "3.1.18",
+        "glob-watcher": "0.0.6",
+        "graceful-fs": "3.0.11",
+        "mkdirp": "0.5.1",
+        "strip-bom": "1.0.0",
+        "through2": "0.6.5",
+        "vinyl": "0.4.6"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+          "integrity": "sha1-xhJqkK1Pctv1rNskPMN3JP6T/B8="
+        },
+        "clone-stats": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+          "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "requires": {
+            "natives": "1.1.4"
+          }
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "strip-bom": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+          "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
+          "requires": {
+            "first-chunk-stream": "1.0.0",
+            "is-utf8": "0.2.1"
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
+          "requires": {
+            "clone": "0.2.0",
+            "clone-stats": "0.0.1"
+          }
+        }
+      }
+    },
+    "vinyl-paths": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-paths/-/vinyl-paths-1.0.0.tgz",
+      "integrity": "sha1-/Ccq2pFbTD6CZM+wbeddPOB8ip4=",
+      "requires": {
+        "through2": "0.6.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
+          }
+        }
+      }
+    },
+    "vinyl-sourcemaps-apply": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+      "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+      "requires": {
+        "source-map": "0.5.7"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        }
+      }
+    },
+    "websocket-driver": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
+      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "requires": {
+        "http-parser-js": "0.4.13",
+        "websocket-extensions": "0.1.3"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+      "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "window-size": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+      "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
+    },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "requires": {
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
+      }
+    },
+    "xdg-basedir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.7"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xmlhttprequest-ssl": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yargs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+      "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
+      "requires": {
+        "camelcase": "3.0.0",
+        "cliui": "3.2.0",
+        "decamelize": "1.2.0",
+        "get-caller-file": "1.0.3",
+        "os-locale": "1.4.0",
+        "read-pkg-up": "1.0.1",
+        "require-directory": "2.1.1",
+        "require-main-filename": "1.0.1",
+        "set-blocking": "2.0.0",
+        "string-width": "1.0.2",
+        "which-module": "1.0.0",
+        "window-size": "0.2.0",
+        "y18n": "3.2.1",
+        "yargs-parser": "4.2.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+      "requires": {
+        "camelcase": "3.0.0"
+      }
+    },
+    "yazl": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+      "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+      "requires": {
+        "buffer-crc32": "0.2.13"
+      }
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    }
+  }
 }

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -34,7 +34,7 @@
     "lodash": "^3.10.0",
     "minimist": "^1.1.0",
     "node-bourbon": "4.2.3",
-    "npm-keyword": "^5.0.0",
+    "npms-keyword": "^1.2.0",
     "package-json": "^5.0.0",
     "plugin-error": "^1.0.1",
     "portfinder": "^1.0.13",


### PR DESCRIPTION
Replaced npm-keyword dependency by npms-keyword, that uses npms.io as search API. Improved _matchesSearchTerms function to support more flexible searches, that calculates the accuracy of the terms relative to package name and description.