### PR TITLE
Don't overwrite rubySass setting when upgrading theme

### DIFF
--- a/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/6.2/upgrade.js
@@ -100,7 +100,6 @@ module.exports = function(options) {
 		let lfrThemeConfig = require('../../liferay_theme_config.js');
 
 		lfrThemeConfig.setConfig({
-			rubySass: false,
 			version: '7.0',
 		});
 

--- a/packages/liferay-theme-tasks/lib/upgrade/7.0/upgrade.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/7.0/upgrade.js
@@ -85,7 +85,6 @@ module.exports = function(options) {
 		let lfrThemeConfig = require('../../liferay_theme_config.js');
 
 		lfrThemeConfig.setConfig({
-			rubySass: false,
 			version: '7.1',
 		});
 

--- a/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
@@ -98,7 +98,7 @@ describe('config', () => {
 			const themeConfig = lfrThemeConfig.getConfig();
 
 			expect(themeConfig.version).toBe('7.0');
-			expect(themeConfig.rubySass).toBe(false);
+			expect(themeConfig.rubySass).toBe(true);
 
 			const lookAndFeelPath = path.join(
 				tempPath,


### PR DESCRIPTION
I have sent this in a different PR because it seemed that the `rubySass` overwrite was made on purpose, so I'm not sure if this will break some other thing.

If unsure, just don't merge this PR but only [this one](https://github.com/liferay/liferay-themes-sdk/pull/40)