### PR TITLE
Add option to generate source maps for sass

### DIFF
--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -59,10 +59,11 @@ module.exports = function(options) {
 			themeConfig.version
 		);
 		let gulpSourceMaps = require('gulp-sourcemaps');
+		let generateSassSourceMaps = storage.get('generateSassSourceMaps');
 
 		let sassOptions = getSassOptions(options.sassOptions, {
 			includePaths: getSassIncludePaths(themeConfig.rubySass),
-			sourceMap: false,
+			sourceMap: generateSassSourceMaps || false,
 		});
 
 		let cssBuild = pathBuild + '/_css';
@@ -89,11 +90,12 @@ module.exports = function(options) {
 			themeConfig.version
 		);
 		let gulpSourceMaps = require('gulp-sourcemaps');
+		let generateSassSourceMaps = storage.get('generateSassSourceMaps');
 
 		let sassOptions = getSassOptions(options.sassOptions, {
 			compass: true,
 			loadPath: getSassIncludePaths(themeConfig.rubySass),
-			sourcemap: false,
+			sourcemap: generateSassSourceMaps || false,
 		});
 
 		let cssBuild = pathBuild + '/_css';


### PR DESCRIPTION
Source maps would contribute a lot for theme development.
To enable it, add `"generateSassSourceMaps": true` to `liferay-theme.json`.
