### PR TITLE
Fixes #106: changed to read from src, overwrite liferay-hook.xml

### DIFF
--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -92,7 +92,7 @@ module.exports = function(options) {
 	});
 
 	gulp.task('build:hook', function() {
-		let languageProperties = themeUtil.getLanguageProperties(pathBuild);
+		let languageProperties = themeUtil.getLanguageProperties(pathSrc);
 
 		return gulp
 			.src(path.join(pathBuild, 'WEB-INF/liferay-hook.xml'))
@@ -114,7 +114,7 @@ module.exports = function(options) {
 					],
 				})
 			)
-			.pipe(plugins.rename('liferay-hook.xml.processed'))
+			.pipe(plugins.rename('liferay-hook.xml'))
 			.pipe(gulp.dest(path.join(pathBuild, 'WEB-INF')));
 	});
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79657

Running Gulp Deploy with a liferay-hook.xml containing a wildcard would generate a blank liferay-hook.xml.processed, as well as a liferay-hook.xml containing the wildcard (rather than generated filenames). Changed the code to read from src/ instead of build/, and to rename liferay-hook.xml.procesed to liferay-hook.xml.