### PR TITLE
Remove rubySass

### DIFF
--- a/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/app/__tests__/index.test.js
@@ -315,7 +315,6 @@ describe('liferay-theme:app unit tests', function() {
 // 			function() {
 // 				var pkg = getPackage(defaults.themeId);
 //
-// 				chaiAssert.equal(pkg.liferayTheme.rubySass, false);
 // 				chaiAssert.equal(pkg.liferayTheme.templateLanguage, 'ftl');
 // 				chaiAssert.equal(pkg.liferayTheme.version, '7.1');
 // 				chaiAssert.equal(pkg.name, defaults.themeId);
@@ -391,7 +390,6 @@ describe('liferay-theme:app unit tests', function() {
 // 			function() {
 // 				var pkg = getPackage(defaults.themeId);
 //
-// 				chaiAssert.equal(pkg.liferayTheme.rubySass, false);
 // 				chaiAssert.equal(pkg.liferayTheme.templateLanguage, 'ftl');
 // 				chaiAssert.equal(pkg.liferayTheme.version, '7.0');
 // 				chaiAssert.equal(pkg.name, defaults.themeId);

--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -336,7 +336,6 @@ module.exports = yeoman.generators.Base.extend({
 
 	_setDefaults: function(liferayVersion) {
 		_.defaults(this, {
-			rubySass: false,
 			templateLanguage: 'ftl',
 		});
 	},

--- a/packages/generator-liferay-theme/generators/app/templates/_package.json
+++ b/packages/generator-liferay-theme/generators/app/templates/_package.json
@@ -8,7 +8,6 @@
 	"liferayTheme": {
 		"baseTheme": "styled",
 		"screenshot": "",
-		"rubySass": false,
 		"templateLanguage": "<%= templateLanguage %>",
 		"version": "<%= liferayVersion %>"
 	},

--- a/packages/generator-liferay-theme/generators/import/__tests__/index.test.js
+++ b/packages/generator-liferay-theme/generators/import/__tests__/index.test.js
@@ -99,7 +99,6 @@ describe('liferay-theme:import unit tests', function() {
 // 		runGenerator(null, function() {
 // 			var pkg = getPackage();
 //
-// 			assert.equal(pkg.liferayTheme.rubySass, true);
 // 			assert.equal(pkg.liferayTheme.templateLanguage, 'vm');
 // 			assert.equal(pkg.liferayTheme.version, '6.2');
 // 			assert.equal(pkg.version, '1.0.0');

--- a/packages/generator-liferay-theme/generators/import/templates/_package.json
+++ b/packages/generator-liferay-theme/generators/import/templates/_package.json
@@ -8,7 +8,6 @@
 	"liferayTheme": {
 		"baseTheme": "styled",
 		"screenshot": "",
-		"rubySass": false,
 		"templateLanguage": "<%= templateLanguage %>",
 		"version": "6.2"
 	},

--- a/packages/liferay-theme-deps-7.0/package.json
+++ b/packages/liferay-theme-deps-7.0/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "compass-mixins": "0.12.10",
-    "gulp-ruby-sass": "^2.0.6",
     "gulp-sass": "3.2.0",
     "liferay-frontend-common-css": "~1.0.4",
     "liferay-frontend-theme-classic-web": "~2.0.0",

--- a/packages/liferay-theme-deps-7.1/package.json
+++ b/packages/liferay-theme-deps-7.1/package.json
@@ -2,7 +2,6 @@
   "author": "Chema Balsas <jose.balsas@liferay.com> (https://github.com/jbalsas)",
   "dependencies": {
     "compass-mixins": "0.12.10",
-    "gulp-ruby-sass": "^2.0.6",
     "gulp-sass": "3.2.0",
     "liferay-frontend-common-css": "1.0.4",
     "liferay-frontend-theme-classic-web": "2.0.2",

--- a/packages/liferay-theme-es2015-hook/README.md
+++ b/packages/liferay-theme-es2015-hook/README.md
@@ -23,7 +23,6 @@ After npm is done installing the dependency you must add the hook to the `lifera
   "liferayTheme": {
     "baseTheme": "styled",
     "hookModules": ["liferay-theme-es2015-hook"],
-    "rubySass": false,
     "templateLanguage": "ftl",
     "version": "7.0"
   },

--- a/packages/liferay-theme-tasks/README.md
+++ b/packages/liferay-theme-tasks/README.md
@@ -222,7 +222,6 @@ The `liferayTheme` object is located in a theme's package.json file and contains
 	],
 	"liferayTheme": {
 		"baseTheme": "styled",
-		"rubySass": false,
 		"templateLanguage": "ftl",
 		"version": "7.0"
 	},
@@ -243,14 +242,6 @@ Determines the base theme. This property is set by the `extend` task.
 The name or names of npm modules. These modules must expose a function that follows the same pattern as a [hookFn](#hookFn).
 
 If a module is listed in `hookModules`, it must also be added to the `devDependencies` of the theme.
-
-### rubySass
-
-If set to true `gulp-ruby-sass` is used as sass compiler. If set to false `gulp-sass` is used.
-
-If changing this property from the default value, the appropriate sass compiler will need to be added as a dev dependency of your theme.
-
-For example, if your theme is intended for Liferay Portal 7.0 and you set `rubySass` to `true`, you will then need to add `gulp-ruby-sass` to the `devDependencies` of your theme and run `npm install`.
 
 ### themelets
 

--- a/packages/liferay-theme-tasks/lib/__tests__/doctor.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/doctor.test.js
@@ -41,7 +41,7 @@ it('should throw appropriate error message', () => {
 
 	expect(() =>
 		doctor({themeConfig: pkgJson, haltOnMissingDeps: true, tasks: []})
-	).toThrow(new Error('Missing 2 theme dependencies'));
+	).toThrow(new Error('Missing 1 theme dependencies'));
 });
 
 it('should look for dependencies regardless if devDependency or not', () => {
@@ -56,7 +56,7 @@ it('should look for dependencies regardless if devDependency or not', () => {
 	).not.toThrow();
 });
 
-it('should replace supportCompass with rubySass', () => {
+it('should remove supportCompass', () => {
 	const pkgJsonPath = path.join(tempPath, 'package.json');
 	const pkgJson = require(pkgJsonPath);
 
@@ -67,7 +67,6 @@ it('should replace supportCompass with rubySass', () => {
 	const liferayTheme = updatedPkg.liferayTheme;
 
 	expect(liferayTheme.baseTheme).toBe('styled');
-	expect(liferayTheme.rubySass).toBe(false);
 	expect(liferayTheme.version).toBe('7.0');
 	expect(liferayTheme.supportCompass).toBeUndefined();
 });

--- a/packages/liferay-theme-tasks/lib/__tests__/fixtures/doctor/_package.json
+++ b/packages/liferay-theme-tasks/lib/__tests__/fixtures/doctor/_package.json
@@ -8,7 +8,6 @@
 		"baseTheme": {
 			"liferayTheme": {
 				"baseTheme": "styled",
-				"rubySass": false,
 				"screenshot": "",
 				"templateLanguage": "vm",
 				"version": "7.0"
@@ -19,7 +18,6 @@
 			},
 			"version": "1.0.0"
 		},
-		"rubySass": true,
 		"themeletDependencies": {
 			"test-themelet": {
 				"liferayTheme": {

--- a/packages/liferay-theme-tasks/lib/__tests__/fixtures/doctor/_package_mixed_dependencies.json
+++ b/packages/liferay-theme-tasks/lib/__tests__/fixtures/doctor/_package_mixed_dependencies.json
@@ -6,7 +6,6 @@
 	],
 	"liferayTheme": {
 		"baseTheme": "styled",
-		"rubySass": false,
 		"themeletDependencies": {},
 		"version": "7.0"
 	},

--- a/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/liferay_theme_config.test.js
@@ -38,12 +38,12 @@ it('getConfig should get only liferayTheme namespaced properties from package.js
 	expect(packageJSON.liferayTheme).toEqual(themeConfig);
 });
 
-it('removeConfig should remove dependencies from package.json', () => {
-	lfrThemeConfig.removeConfig(['rubySass']);
+it('removeConfig should remove properties from package.json', () => {
+	lfrThemeConfig.removeConfig(['templateLanguage']);
 
 	const liferayTheme = lfrThemeConfig.getConfig();
 
-	expect(liferayTheme).not.toHaveProperty('rubySass');
+	expect(liferayTheme).not.toHaveProperty('templateLanguage');
 });
 
 it('removeDependencies should remove dependencies from package.json', () => {

--- a/packages/liferay-theme-tasks/lib/__tests__/options.test.js
+++ b/packages/liferay-theme-tasks/lib/__tests__/options.test.js
@@ -24,7 +24,6 @@ it('options should return default options with no config passed', () => {
 		baseTheme: {
 			liferayTheme: {
 				baseTheme: 'styled',
-				rubySass: false,
 				screenshot: '',
 				templateLanguage: 'vm',
 				version: '7.0',
@@ -38,7 +37,6 @@ it('options should return default options with no config passed', () => {
 		pathBuild: './build',
 		pathDist: './dist',
 		pathSrc: './src',
-		rubySass: false,
 		sassOptions: {},
 		templateLanguage: 'ftl',
 		themeletDependencies: {
@@ -66,7 +64,6 @@ it('options should return previously set options if no config is passed', () => 
 		baseTheme: {
 			liferayTheme: {
 				baseTheme: 'styled',
-				rubySass: false,
 				screenshot: '',
 				templateLanguage: 'vm',
 				version: '7.0',
@@ -81,7 +78,6 @@ it('options should return previously set options if no config is passed', () => 
 		pathBuild: './custom_build_path',
 		pathDist: './dist',
 		pathSrc: './src',
-		rubySass: false,
 		sassOptions: {},
 		templateLanguage: 'ftl',
 		themeletDependencies: {

--- a/packages/liferay-theme-tasks/lib/doctor.js
+++ b/packages/liferay-theme-tasks/lib/doctor.js
@@ -31,9 +31,7 @@ function doctor({
 		dependencies = _.defaults(dependencies, themeConfig.devDependencies);
 	}
 
-	if (
-		!_.isUndefined(themeConfig.liferayTheme.supportCompass)
-	) {
+	if (!_.isUndefined(themeConfig.liferayTheme.supportCompass)) {
 		lfrThemeConfig.removeConfig(['supportCompass']);
 	}
 

--- a/packages/liferay-theme-tasks/lib/doctor.js
+++ b/packages/liferay-theme-tasks/lib/doctor.js
@@ -31,22 +31,13 @@ function doctor({
 		dependencies = _.defaults(dependencies, themeConfig.devDependencies);
 	}
 
-	let rubySass = themeConfig.liferayTheme.rubySass;
-
 	if (
-		!_.isUndefined(themeConfig.liferayTheme.supportCompass) &&
-		_.isUndefined(rubySass)
+		!_.isUndefined(themeConfig.liferayTheme.supportCompass)
 	) {
-		rubySass = themeConfig.liferayTheme.supportCompass;
-
-		lfrThemeConfig.setConfig({
-			rubySass: rubySass,
-		});
-
 		lfrThemeConfig.removeConfig(['supportCompass']);
 	}
 
-	let missingDeps = checkMissingDeps(liferayVersion, dependencies, rubySass);
+	let missingDeps = checkMissingDeps(liferayVersion, dependencies);
 
 	checkDependencySources(themeConfig.liferayTheme);
 
@@ -118,7 +109,7 @@ function checkDependencySources(liferayTheme) {
 	}
 }
 
-function checkMissingDeps(version, dependencies, rubySass) {
+function checkMissingDeps(version, dependencies) {
 	let missingDeps = 0;
 
 	missingDeps = logMissingDeps(
@@ -126,14 +117,6 @@ function checkMissingDeps(version, dependencies, rubySass) {
 		`liferay-theme-deps-${version}`,
 		missingDeps
 	);
-
-	if (rubySass) {
-		missingDeps = logMissingDeps(
-			dependencies,
-			'gulp-ruby-sass',
-			missingDeps
-		);
-	}
 
 	return missingDeps;
 }

--- a/packages/liferay-theme-tasks/lib/options.js
+++ b/packages/liferay-theme-tasks/lib/options.js
@@ -12,7 +12,6 @@ function getOptions(config) {
 		config.pathBuild = config.pathBuild || './build';
 		config.pathDist = config.pathDist || './dist';
 		config.pathSrc = config.pathSrc || './src';
-		config.rubySass = config.rubySass || false;
 		config.sassOptions = config.sassOptions || {};
 
 		let themeConfig = lfrThemeConfig.getConfig();

--- a/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
+++ b/packages/liferay-theme-tasks/lib/prompts/__tests__/extend_prompt.test.js
@@ -94,7 +94,6 @@ it('_afterPromptTheme should save and install new dependencies', () => {
 				liferayTheme: {
 					baseTheme: 'styled',
 					screenshot: '',
-					rubySass: false,
 					templateLanguage: 'ftl',
 					version: '7.0',
 					themeletDependencies: {},

--- a/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
+++ b/packages/liferay-theme-tasks/lib/upgrade/__tests__/upgrade.test.js
@@ -45,7 +45,6 @@ describe('black list', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -83,7 +82,6 @@ describe('config', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -98,7 +96,6 @@ describe('config', () => {
 			const themeConfig = lfrThemeConfig.getConfig();
 
 			expect(themeConfig.version).toBe('7.0');
-			expect(themeConfig.rubySass).toBe(true);
 
 			const lookAndFeelPath = path.join(
 				tempPath,
@@ -133,7 +130,6 @@ describe('convert bootstrap', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -169,7 +165,6 @@ describe('create backup files', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -209,7 +204,6 @@ describe('create css diff', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -247,7 +241,6 @@ describe('create deprecated mixins', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -282,7 +275,6 @@ describe('log changes', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -311,7 +303,6 @@ describe('replace compass', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 
@@ -349,7 +340,6 @@ describe('upgrade templates', () => {
 			version: '6.2',
 			registerTasksOptions: {
 				pathSrc: 'src',
-				rubySass: true,
 			},
 		});
 

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -56,7 +56,6 @@
 		"bluebird": "^3.3.4",
 		"gogo-shell-helper": "^0.0.8",
 		"gulp": "^3.9.1",
-		"gulp-ruby-sass": "^2.0.6",
 		"gulp-sass": "^3.1.0"
 	},
 	"engines": {

--- a/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -11,33 +11,13 @@ const initCwd = process.cwd();
 afterAll(() => {
 	// Clean things on exit to avoid GulpStorage.save() errors because of left
 	// over async operations when changing tests.
-	['lib_sass_build_task', 'ruby_sass_build_task'].forEach(namespace =>
-		testUtil.cleanTempTheme('base-theme', '7.0', namespace, initCwd)
-	);
+	testUtil.cleanTempTheme('base-theme', '7.0', 'lib_sass_build_task', initCwd);
 });
 
-describe('using lib_sass', () =>
-	testBoilerplate(test, {
-		namespace: 'lib_sass_build_task',
-		themeName: 'base-theme',
-		version: '7.0',
-		rubySass: false,
-	}));
-
-describe('using ruby_sass', () =>
-	testBoilerplate(test, {
-		namespace: 'ruby_sass_build_task',
-		themeName: 'base-theme',
-		version: '7.0',
-		rubySass: true,
-	}));
-
-function testBoilerplate(test, options) {
-	const namespace = options.namespace;
-	const rubySass = options.rubySass || false;
-	const themeName = options.themeName;
-	const version = options.version;
-
+describe('using lib_sass', () => {
+	const namespace = 'lib_sass_build_task';
+	const themeName = 'base-theme';
+	const version = '7.0';
 	const sassOptionsSpy = sinon.spy();
 	let runSequence;
 	let buildPath;
@@ -56,21 +36,13 @@ function testBoilerplate(test, options) {
 				sassOptions: defaults => {
 					sassOptionsSpy();
 
-					if (rubySass) {
-						expect(defaults.compass).toBeTruthy();
-						expect(defaults.loadPath).toBeTruthy();
-					} else {
-						expect(defaults.includePaths).toBeTruthy();
-					}
+					expect(defaults.includePaths).toBeTruthy();
 
 					return defaults;
 				},
 				hookFn: buildHookFn,
-				rubySass: rubySass,
 			},
-			themeConfig: {
-				rubySass: rubySass,
-			},
+			themeConfig: {},
 			themeName: themeName,
 			version: version,
 		});
@@ -343,4 +315,4 @@ function testBoilerplate(test, options) {
 
 		cb();
 	}
-}
+});

--- a/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
+++ b/packages/liferay-theme-tasks/tasks/__tests__/build.test.js
@@ -11,7 +11,12 @@ const initCwd = process.cwd();
 afterAll(() => {
 	// Clean things on exit to avoid GulpStorage.save() errors because of left
 	// over async operations when changing tests.
-	testUtil.cleanTempTheme('base-theme', '7.0', 'lib_sass_build_task', initCwd);
+	testUtil.cleanTempTheme(
+		'base-theme',
+		'7.0',
+		'lib_sass_build_task',
+		initCwd
+	);
 });
 
 describe('using lib_sass', () => {

--- a/packages/liferay-theme-tasks/tasks/build.js
+++ b/packages/liferay-theme-tasks/tasks/build.js
@@ -67,27 +67,23 @@ module.exports = function(options) {
 	// Temp fix for libSass compilation issue with empty url() functions
 
 	gulp.task('build:fix-url-functions', function(cb) {
-		if (themeConfig.rubySass) {
-			cb();
-		} else {
-			gulp.src(pathBuild + '/_css/**/*.css')
-				.pipe(
-					replace({
-						patterns: [
-							{
-								match: /url\(url\(\)/g,
-								replacement: 'url()',
-							},
-						],
-					})
-				)
-				.pipe(
-					gulp.dest(pathBuild + '/_css', {
-						overwrite: true,
-					})
-				)
-				.on('end', cb);
-		}
+		gulp.src(pathBuild + '/_css/**/*.css')
+			.pipe(
+				replace({
+					patterns: [
+						{
+							match: /url\(url\(\)/g,
+							replacement: 'url()',
+						},
+					],
+				})
+			)
+			.pipe(
+				gulp.dest(pathBuild + '/_css', {
+					overwrite: true,
+				})
+			)
+			.on('end', cb);
 	});
 
 	gulp.task('build:hook', function() {

--- a/packages/liferay-theme-tasks/tasks/build/compile-css.js
+++ b/packages/liferay-theme-tasks/tasks/build/compile-css.js
@@ -43,9 +43,7 @@ module.exports = function(options) {
 
 		const themeConfig = lfrThemeConfig.getConfig();
 
-		let compileTask = themeConfig.rubySass
-			? 'build:compile-ruby-sass'
-			: 'build:compile-lib-sass';
+		let compileTask = 'build:compile-lib-sass';
 
 		runSequence(compileTask, cb);
 	});
@@ -61,7 +59,7 @@ module.exports = function(options) {
 		let gulpSourceMaps = require('gulp-sourcemaps');
 
 		let sassOptions = getSassOptions(options.sassOptions, {
-			includePaths: getSassIncludePaths(themeConfig.rubySass),
+			includePaths: getSassIncludePaths(),
 			sourceMap: true,
 		});
 
@@ -80,39 +78,6 @@ module.exports = function(options) {
 			)
 			.on('error', handleScssError)
 			.pipe(gulpIf(sassOptions.sourceMap, gulpSourceMaps.write('.')))
-			.pipe(gulp.dest(cssBuild))
-			.on('end', cb);
-	});
-
-	gulp.task('build:compile-ruby-sass', function(cb) {
-		const themeConfig = lfrThemeConfig.getConfig();
-
-		let gulpIf = require('gulp-if');
-		let gulpRubySass = themeUtil.requireDependency(
-			'gulp-ruby-sass',
-			themeConfig.version
-		);
-		let gulpSourceMaps = require('gulp-sourcemaps');
-
-		let sassOptions = getSassOptions(options.sassOptions, {
-			compass: true,
-			loadPath: getSassIncludePaths(themeConfig.rubySass),
-			sourcemap: true,
-		});
-
-		const postCSSOptions = getPostCSSOptions(options.postcss);
-
-		let cssBuild = pathBuild + '/_css';
-
-		let srcPath = path.join(cssBuild, '*.scss');
-
-		gulpRubySass(srcPath, sassOptions)
-			.pipe(gulpIf(sassOptions.sourcemap, gulpSourceMaps.init()))
-			.pipe(
-				gulpIf(postCSSOptions.enabled, postcss(postCSSOptions.plugins))
-			)
-			.on('error', handleScssError)
-			.pipe(gulpIf(sassOptions.sourcemap, gulpSourceMaps.write('.')))
 			.pipe(gulp.dest(cssBuild))
 			.on('end', cb);
 	});
@@ -143,7 +108,7 @@ function getPostCSSOptions(config) {
 	return postCSSOptions;
 }
 
-function getSassIncludePaths(rubySass) {
+function getSassIncludePaths() {
 	let includePaths = [
 		themeUtil.resolveDependency(
 			divert('dependencies').getDependencyName('mixins')
@@ -151,10 +116,7 @@ function getSassIncludePaths(rubySass) {
 	];
 
 	includePaths = concatBourbonIncludePaths(includePaths);
-
-	if (!rubySass) {
-		includePaths.push(path.dirname(require.resolve('compass-mixins')));
-	}
+	includePaths.push(path.dirname(require.resolve('compass-mixins')));
 
 	return includePaths;
 }

--- a/packages/liferay-theme-tasks/test/fixtures/themes/6.2/upgrade-theme/package.json
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/6.2/upgrade-theme/package.json
@@ -6,7 +6,6 @@
 	],
 	"liferayTheme": {
 		"baseTheme": "styled",
-		"rubySass": true,
 		"screenshot": "",
 		"templateLanguage": "vm",
 		"version": "6.2"

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.0/base-theme/package.json
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.0/base-theme/package.json
@@ -8,7 +8,6 @@
     "baseTheme": {
       "liferayTheme": {
         "baseTheme": "styled",
-        "rubySass": false,
         "screenshot": "",
         "templateLanguage": "vm",
         "version": "7.0"
@@ -19,7 +18,6 @@
       },
       "version": "1.0.0"
     },
-    "rubySass": false,
     "templateLanguage": "ftl",
     "themeletDependencies": {
       "test-themelet": {

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.0/explicit-dependency-theme/package.json
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.0/explicit-dependency-theme/package.json
@@ -4,7 +4,6 @@
 	"keywords": ["liferay-theme"],
 	"liferayTheme": {
 		"baseTheme": "styled",
-		"rubySass": false,
 		"templateLanguage": "ftl",
 		"themeletDependencies": {},
 		"version": "7.0"

--- a/packages/liferay-theme-tasks/test/fixtures/themes/7.0/kickstart-theme/package.json
+++ b/packages/liferay-theme-tasks/test/fixtures/themes/7.0/kickstart-theme/package.json
@@ -6,7 +6,6 @@
 		"baseTheme": {
 			"liferayTheme": {
 				"baseTheme": "styled",
-				"rubySass": false,
 				"screenshot": "",
 				"templateLanguage": "vm",
 				"version": "7.0"
@@ -17,7 +16,6 @@
 			},
 			"version": "1.0.0"
 		},
-		"rubySass": false,
 		"themeletDependencies": {
 			"test-themelet": {
 				"liferayTheme": {

--- a/packages/liferay-theme-tasks/test/util.js
+++ b/packages/liferay-theme-tasks/test/util.js
@@ -267,7 +267,6 @@ function copyTempTheme(options) {
 				pathBuild: './custom_build_path',
 				gulp: gulp,
 				pathSrc: './custom_src_path',
-				rubySass: false,
 				insideTests: true,
 			},
 			options.registerTasksOptions


### PR DESCRIPTION
We previously had [an issue](https://github.com/liferay/liferay-themes-sdk/issues/137) for removing the ruby-sass option from the theme generator because it is no longer required on Windows (which was the reason it was initially added).
    
In preparation for the next major release we remove the remaining traces of it. There is still one indirect reference to it in the form of a transitory dependency, as reported by `yarn why gulp-ruby-sass`:
    
```
=> Found "gulp-ruby-sass@2.1.1"
info Reasons this module exists
   - "_project_#liferay-theme-tasks#liferay-theme-deps-6.2" depends on it
   - Hoisted from "_project_#liferay-theme-tasks#liferay-theme-deps-6.2#gulp-ruby-sass"
```
    
This was added in 7b833e937500bc3e7339ec1b3eb24 ("Adds liferay-theme-deps-6.2 dependency to support upgrading from 6.2 with the 8.x version of the theme-tasks directly", August 2018). I am not totally sure, but I think we might be able to remove it from there too.
    
Test plan: `yarn test`
    
Closes: https://github.com/liferay/liferay-themes-sdk/issues/152
