### PR TITLE
Remove lodash from liferay-theme-finder

### DIFF
--- a/packages/liferay-theme-finder/__tests__/find.test.js
+++ b/packages/liferay-theme-finder/__tests__/find.test.js
@@ -1,7 +1,10 @@
-var _ = require('lodash');
 var path = require('path');
 
 var themeFinder = require('../index');
+
+function isObject(value) {
+	return value != null && typeof value === 'object';
+}
 
 beforeEach(() => {
 	jest.setTimeout(30000);
@@ -9,7 +12,7 @@ beforeEach(() => {
 
 it('find should return an object when searching for global modules', done => {
 	themeFinder.find(themeResults => {
-		expect(_.isObject(themeResults)).toBe(true);
+		expect(isObject(themeResults)).toBe(true);
 
 		done();
 	});
@@ -22,13 +25,14 @@ it('find should return an object when searching for npm modules', done => {
 			themelet: true,
 		},
 		themeResults => {
-			_.forEach(themeResults, (item, index) => {
-				expect(_.isObject(item)).toBe(true);
-				expect(_.isObject(item.liferayTheme)).toBe(true);
+			expect(Array.isArray(themeResults)).toBe(true);
+			themeResults.forEach(item => {
+				expect(isObject(item)).toBe(true);
+				expect(isObject(item.liferayTheme)).toBe(true);
 				expect(item.keywords.indexOf('liferay-theme') > -1).toBe(true);
 			});
 
-			expect(_.isObject(themeResults)).toBe(true);
+			expect(isObject(themeResults)).toBe(true);
 
 			done();
 		}

--- a/packages/liferay-theme-finder/__tests__/name.test.js
+++ b/packages/liferay-theme-finder/__tests__/name.test.js
@@ -1,4 +1,3 @@
-var _ = require('lodash');
 var path = require('path');
 
 var themeFinder = require('../index');
@@ -12,7 +11,7 @@ it('name should retrieve package.json file from npm', done => {
 
 	themeFinder.name(pkgName, (err, pkg) => {
 		expect(err).toBeNull();
-		expect(_.isObject(pkg.liferayTheme)).toBe(true);
+		expect(pkg.liferayTheme).toMatchObject({version: expect.stringMatching(/^\d+\.\d+/)});
 		expect(pkg.keywords.indexOf('liferay-theme') > -1).toBe(true);
 		expect(pkg.name).toBe(pkgName);
 

--- a/packages/liferay-theme-finder/__tests__/name.test.js
+++ b/packages/liferay-theme-finder/__tests__/name.test.js
@@ -11,7 +11,9 @@ it('name should retrieve package.json file from npm', done => {
 
 	themeFinder.name(pkgName, (err, pkg) => {
 		expect(err).toBeNull();
-		expect(pkg.liferayTheme).toMatchObject({version: expect.stringMatching(/^\d+\.\d+/)});
+		expect(pkg.liferayTheme).toMatchObject({
+			version: expect.stringMatching(/^\d+\.\d+/),
+		});
 		expect(pkg.keywords.indexOf('liferay-theme') > -1).toBe(true);
 		expect(pkg.name).toBe(pkgName);
 

--- a/packages/liferay-theme-finder/package.json
+++ b/packages/liferay-theme-finder/package.json
@@ -6,7 +6,6 @@
     "cross-spawn": "^4.0.0",
     "fs-extra": "^0.24.0",
     "globby": "^6.0.0",
-    "lodash": "^4.15.0",
     "npm-keyword": "^5.0.0",
     "package-json": "^5.0.0",
     "spawn-sync": "^1.0.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7588,7 +7588,7 @@ lodash@^2.4.1, lodash@~2.4.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
   integrity sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=
 
-lodash@^4.0.0, lodash@^4.11.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.7.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.11.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
As we're not using Babel or polyfills in here at the moment, I tried to keep this pretty squarely within ES5-land; please let me know if I missed anything. There were some arrow functions in the code already on the test side, but I don't think I added any outside the tests. I am using a `Set` in one place, which is officially ES6; we could easily get away with just using an array there (we're doing intersection of tiny arrays).

Related: https://github.com/liferay/liferay-themes-sdk/issues/141