### PR TITLE
Remove _.isPlainObject calls in divert.js (x2)

### DIFF
--- a/packages/generator-liferay-theme/lib/divert/index.js
+++ b/packages/generator-liferay-theme/lib/divert/index.js
@@ -1,6 +1,11 @@
 'use strict';
 
-let _ = require('lodash');
+function isPlainObject(value) {
+	return (
+		value !== null &&
+		Object.prototype.toString.call(value) === '[object Object]'
+	);
+}
 
 function divert(moduleName, version) {
 	version = version || divert.defaultVersion;
@@ -30,7 +35,7 @@ function safeRequire(moduleName) {
 		}
 	}
 
-	if (!_.isPlainObject(module)) {
+	if (!isPlainObject(module)) {
 		throw new Error(
 			'Only modules exporting plain objects can be used with divert'
 		);

--- a/packages/liferay-theme-tasks/lib/divert/common/kickstart_prompt_helpers.js
+++ b/packages/liferay-theme-tasks/lib/divert/common/kickstart_prompt_helpers.js
@@ -3,7 +3,6 @@
 const inquirer = require('inquirer');
 const _ = require('lodash');
 
-const divert = require('../../divert');
 const GlobalModulePrompt = require('../../prompts/global_module_prompt');
 const NPMModulePrompt = require('../../prompts/npm_module_prompt');
 const themeUtil = require('../../util');

--- a/packages/liferay-theme-tasks/lib/divert/index.js
+++ b/packages/liferay-theme-tasks/lib/divert/index.js
@@ -1,6 +1,11 @@
 'use strict';
 
-let _ = require('lodash');
+function isPlainObject(value) {
+	return (
+		value !== null &&
+		Object.prototype.toString.call(value) === '[object Object]'
+	);
+}
 
 let lfrThemeConfig = require('../liferay_theme_config');
 
@@ -30,7 +35,7 @@ function safeRequire(moduleName) {
 		}
 	}
 
-	if (!_.isPlainObject(module)) {
+	if (!isPlainObject(module)) {
 		throw new Error(
 			'Only modules exporting plain objects can be used with divert'
 		);

--- a/packages/liferay-theme-tasks/tasks/deploy.js
+++ b/packages/liferay-theme-tasks/tasks/deploy.js
@@ -8,8 +8,6 @@ const lfrThemeConfig = require('../lib/liferay_theme_config');
 const themeUtil = require('../lib/util');
 const WarDeployer = require('../lib/war_deployer');
 
-const divert = require('../lib/divert');
-
 const themeConfig = lfrThemeConfig.getConfig(true);
 const DEPLOYMENT_STRATEGIES = themeUtil.DEPLOYMENT_STRATEGIES;
 


### PR DESCRIPTION
Also worth noting: these two modules are almost exact duplicates. As a follow-up I am going to look at de-duping them.

Related: https://github.com/liferay/liferay-themes-sdk/issues/141