### PR TITLE
Remove generator dependence on globally installed gulp instance (#172)

### DIFF
--- a/packages/generator-liferay-theme/README.md
+++ b/packages/generator-liferay-theme/README.md
@@ -6,8 +6,8 @@
 
 ## Dependencies
 
-1. Install [Node.JS](http://nodejs.org/), if you don't have it yet.<br>
-2. run `<sudo> npm install -g yo gulp` to install global dependencies.
+1. Install [Node.JS](http://nodejs.org/), if you don't have it yet.
+2. Run `<sudo> npm install -g yo` to install global dependencies.
 
 ## Generator use
 

--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -123,7 +123,9 @@ module.exports = yeoman.generators.Base.extend({
 			this.installDependencies({
 				bower: false,
 				callback: function() {
-					instance.spawnCommand('gulp', ['init']);
+					const gulp = require('gulp');
+					require('liferay-theme-tasks').registerTasks({gulp: gulp});
+					gulp.start('init');
 				},
 			});
 		}

--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -124,7 +124,9 @@ module.exports = yeoman.generators.Base.extend({
 				bower: false,
 				callback: function() {
 					const gulp = require('gulp');
-					require('liferay-theme-tasks').registerTasks({gulp: gulp});
+					require('liferay-theme-tasks').registerTasks({
+						gulp: gulp,
+					});
 					gulp.start('init');
 				},
 			});


### PR DESCRIPTION
If you try to generate a theme without a globally installed copy of gulp you'll get `Error: spawn gulp ENOENT` at the end. We do tell people (in the README) to install gulp globally, but that shouldn't be necessary: it is already a dependency of the generator and we can just use the generator's copy.

Test plan: `yo ./packages/generator-liferay-theme` without a globally installed copy of `gulp` and see it work without blowing up.

Closes: https://github.com/liferay/liferay-themes-sdk/issues/172