### PR TITLE
Remove scary warnings from normalize process in the generator

### DIFF
--- a/packages/liferay-theme-deps-normalize/index.js
+++ b/packages/liferay-theme-deps-normalize/index.js
@@ -2,7 +2,9 @@ var fs = require('fs');
 var path = require('path');
 
 function insertInjectTag(filePath, regex, replacer) {
-	try {
+	const relativePath = path.relative('', filePath);
+
+	if (fs.existsSync(filePath)) {
 		var fileContents = fs.readFileSync(filePath, {
 			encoding: 'utf8',
 		});
@@ -14,8 +16,12 @@ function insertInjectTag(filePath, regex, replacer) {
 		fs.writeFileSync(filePath, fileContents, {
 			encoding: 'utf8',
 		});
-	} catch (e) {
-		console.log('Unable to add inject tags to', filePath);
+
+		console.log(`Completed tag injection for ${relativePath}`);
+	} else {
+		console.log(
+			`Skipping tag injection for ${relativePath} (does not exist)`
+		);
 	}
 }
 


### PR DESCRIPTION
Before this commit, when you created a new 7.1 (or 7.2) theme, you would see this warning in the console:

    Unable to add inject tags to /Users/greghurrell/code/liferay-themes-sdk/zzz-theme/node_modules/liferay-frontend-theme-unstyled/templates/portal_normal.vm

This sounds like an error, but it's totally expected because the theme in 7.1 doesn't have any Velocity templates.

So, this commit reworks things so that you just see non-scary status messages instead.

In 7.1+ you see:

    Completed tag injection for node_modules/liferay-frontend-theme-unstyled/templates/portal_normal.ftl
    Skipping tag injection for node_modules/liferay-frontend-theme-unstyled/templates/portal_normal.vm (does not exist)

In 7.0 you see:

    Completed tag injection for node_modules/liferay-frontend-theme-unstyled/templates/portal_normal.ftl
    Completed tag injection for node_modules/liferay-frontend-theme-unstyled/templates/portal_normal.vm

Extracted from out as a relatively uncontroversial bit from: #174