### PR TITLE
Don't use string-concatenation to build up devDependencies

### DIFF
--- a/packages/generator-liferay-theme/generators/app/index.js
+++ b/packages/generator-liferay-theme/generators/app/index.js
@@ -296,7 +296,14 @@ module.exports = yeoman.generators.Base.extend({
 		var liferayVersion = props.liferayVersion;
 
 		this.appname = props.themeId;
-		this.devDependencies = lookup('devDependencies', liferayVersion);
+		this.devDependencies = JSON.stringify(
+			lookup('devDependencies', liferayVersion),
+			null,
+			2
+		)
+			.split(/\n\s*/)
+			.join('\n\t\t')
+			.replace('\t\t}', '\t}');
 		this.liferayVersion = liferayVersion;
 		this.templateLanguage = props.templateLanguage;
 		this.themeName = props.themeName;

--- a/packages/generator-liferay-theme/generators/app/templates/_package.json
+++ b/packages/generator-liferay-theme/generators/app/templates/_package.json
@@ -1,7 +1,5 @@
 {
-	"devDependencies": {
-	<%= devDependencies %>
-	},
+	"devDependencies": <%= devDependencies %>,
 	"keywords": [
 		"liferay-theme"
 	],

--- a/packages/liferay-theme-tasks/lib/lookup/dependencies.js
+++ b/packages/liferay-theme-tasks/lib/lookup/dependencies.js
@@ -1,18 +1,18 @@
 function devDependencies(version) {
-	const dependencies = [
-		`\t"gulp": "3.9.1",`,
-		`\t\t"liferay-theme-tasks": "8.0.0-rc.3",`,
-	];
+	const dependencies = {
+		'gulp': '3.9.1',
+		'liferay-theme-tasks': '8.0.0-rc.3',
+	};
 
 	if (version === '7.0') {
-		dependencies.push(`\t\t"liferay-theme-deps-7.0": "8.0.0-rc.3"`);
+		dependencies['liferay-theme-deps-7.0'] = '8.0.0-rc.3';
 	} else if (version === '7.1') {
-		dependencies.push(`\t\t"liferay-theme-deps-7.1": "8.0.0-rc.3"`);
+		dependencies['liferay-theme-deps-7.1'] = '8.0.0-rc.3';
 	} else if (version === '7.2') {
-		dependencies.push(`\t\t"liferay-theme-deps-7.2": "8.0.0-rc.3"`);
+		dependencies['liferay-theme-deps-7.2'] = '8.0.0-rc.3';
 	}
 
-	return dependencies.join('\n');
+	return dependencies;
 }
 
 module.exports = {


### PR DESCRIPTION
When I ported us from `divert()` to `lookup()` in #179 I didn't change the string concatenation because I didn't want to change too many things at once.

Here as a follow-up I'm replacing it with `JSON.stringify()`. I'm not totally convinced by this change though. While we got rid of the concatenation (yay!), we now have this `split()`/`join()`/`replace()` song and dance to get the outputted JSON looking exactly how we want it. If we didn't care about that we could just leave all that off.

Anyway, going to put this up as an RFC anyway and see.

Test plan: `yarn test`, use `yo ./packages/generator-liferay-theme` to create a new theme and then inspect that the package.json is correct, including the tabs.

![sample](https://user-images.githubusercontent.com/7074/53739005-0b2a1c80-3e91-11e9-9c6c-020f530995d3.png)
