### PR TITLE
Rename SDK reference to "toolkit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# liferay-themes-sdk
+# liferay-themes-toolkit

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"sinon": "^4.4.6"
 	},
 	"private": true,
-	"repository": "liferay/liferay-themes-sdk/packages/liferay-theme-tasks",
+	"repository": "https://github.com/liferay/liferay-themes-sdk",
 	"scripts": {
 		"ci": "prettier-eslint --list-different '*.{js,json,md}' 'packages/**/*.{js,json,md}' && yarn lint && yarn test",
 		"format": "prettier-eslint --write '*.{js,json,md}' 'packages/**/*.{js,json,md}'",

--- a/packages/generator-liferay-theme/package.json
+++ b/packages/generator-liferay-theme/package.json
@@ -4,7 +4,11 @@
 	"description": "Yeoman generator for creating Liferay themes",
 	"license": "MIT",
 	"main": "generators/app/index.js",
-	"repository": "liferay/liferay-themes-sdk/packages/generator-liferay-theme",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"directory": "packages/generator-liferay-theme"
+	},
 	"author": {
 		"name": "Nate Cavanaugh",
 		"email": "nathan.cavanaugh@liferay.com",

--- a/packages/liferay-theme-deps-7.0/package.json
+++ b/packages/liferay-theme-deps-7.0/package.json
@@ -5,7 +5,11 @@
 	"main": "package.json",
 	"author": "Rob Frampton <rob.g.frampton@gmail.com> (https://github.com/Robert-Frampton)",
 	"license": "ISC",
-	"repository": "liferay/liferay-themes-sdk/packages/liferay-theme-deps-7.0",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"directory": "packages/liferay-theme-deps-7.0"
+	},
 	"dependencies": {
 		"compass-mixins": "0.12.10",
 		"gulp-sass": "3.2.0",

--- a/packages/liferay-theme-deps-7.1/package.json
+++ b/packages/liferay-theme-deps-7.1/package.json
@@ -13,5 +13,9 @@
 	"main": "package.json",
 	"name": "liferay-theme-deps-7.1",
 	"version": "8.0.0-rc.3",
-	"repository": "liferay/liferay-themes-sdk/packages/liferay-theme-deps-7.1"
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"directory": "liferay-theme-deps-7.1"
+	}
 }

--- a/packages/liferay-theme-deps-7.2/package.json
+++ b/packages/liferay-theme-deps-7.2/package.json
@@ -13,5 +13,9 @@
 	"main": "package.json",
 	"name": "liferay-theme-deps-7.2",
 	"version": "8.0.0-rc.3",
-	"repository": "liferay/liferay-themes-sdk/packages/liferay-theme-deps-7.2"
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"directory": "packages/liferay-theme-deps-7.2"
+	}
 }

--- a/packages/liferay-theme-es2015-hook/package.json
+++ b/packages/liferay-theme-es2015-hook/package.json
@@ -1,6 +1,10 @@
 {
 	"name": "liferay-theme-es2015-hook",
-	"repository": "liferay/liferay-themes-sdk/packages/liferay-theme-es2015-hook",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"directory": "packages/liferay-theme-es2015-hook"
+	},
 	"version": "8.0.0-rc.3",
 	"description": "A hook for liferay-theme-tasks that allows for es2015 transpilation and amd module configuration.",
 	"main": "index.js",

--- a/packages/liferay-theme-mixins/package.json
+++ b/packages/liferay-theme-mixins/package.json
@@ -19,6 +19,10 @@
 	"license": "LGPL",
 	"main": "index.js",
 	"name": "liferay-theme-mixins",
-	"repository": "liferay/liferay-themes-sdk/packages/liferay-theme-mixins",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"directory": "packages/liferay-theme-mixins"
+	},
 	"version": "8.0.0-rc.3"
 }

--- a/packages/liferay-theme-tasks/package.json
+++ b/packages/liferay-theme-tasks/package.json
@@ -68,6 +68,10 @@
 	"license": "MIT",
 	"main": "index.js",
 	"name": "liferay-theme-tasks",
-	"repository": "liferay/liferay-themes-sdk/packages/liferay-theme-tasks",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/liferay/liferay-themes-sdk",
+		"directory": "packages/liferay-theme-tasks"
+	},
 	"version": "8.0.0-rc.3"
 }


### PR DESCRIPTION
If we end up actually relocating the repo itself, there are a bunch of URLs that we should probably update too, as per:

https://help.github.com/en/articles/renaming-a-repository

Related: https://github.com/liferay/liferay-themes-sdk/issues/185
